### PR TITLE
refactor: sdl3::events - Modernize/Update SDL3 Events

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -1,7 +1,7 @@
 extern crate sdl3;
 use std::path::Path;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent};
 use sdl3::keyboard::Keycode;
 use sdl3::render::FRect;
 use std::time::Duration;
@@ -55,11 +55,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     while running {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => {
+                }) => {
                     running = false;
                 }
                 _ => {}

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent, MouseButtonState, MouseEvent};
 use sdl3::image::{InitFlag, LoadSurface};
 use sdl3::keyboard::Keycode;
 use sdl3::mouse::Cursor;
@@ -38,12 +38,18 @@ pub fn run(png: &Path) -> Result<(), Box<dyn std::error::Error>> {
     'mainloop: loop {
         for event in events.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
-                    keycode: Option::Some(Keycode::Escape),
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
+                    keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => break 'mainloop,
-                Event::MouseButtonDown { x, y, .. } => {
+                }) => break 'mainloop,
+                Event::Mouse(MouseEvent::Button {
+                    x,
+                    y,
+                    state: MouseButtonState::Down,
+                    ..
+                }) => {
                     canvas.fill_rect(Rect::new(x as i32, y as i32, 1, 1))?;
                     canvas.present();
                 }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent};
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::Color;
 use std::time::Duration;
@@ -26,11 +26,12 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => break 'running,
+                }) => break 'running,
                 _ => {}
             }
         }

--- a/examples/demo_games/a02_woodeneye_008.rs
+++ b/examples/demo_games/a02_woodeneye_008.rs
@@ -1,6 +1,6 @@
 // original code : https://github.com/libsdl-org/SDL/tree/main/examples/demo/02-woodeneye-008
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent, MouseButtonState, MouseEvent};
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::Color;
 use sdl3::rect::Rect;
@@ -598,10 +598,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. } => break 'running,
-                Event::MouseMotion {
+                Event::Quit(_) => break 'running,
+                Event::Mouse(MouseEvent::Motion {
                     which, xrel, yrel, ..
-                } => {
+                }) => {
                     if let Some(index) =
                         whose_mouse(which, &app_state.players, app_state.player_count)
                     {
@@ -626,18 +626,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
 
-                Event::MouseButtonDown { which, .. } => {
+                Event::Mouse(MouseEvent::Button {
+                    which,
+                    state: MouseButtonState::Down,
+                    ..
+                }) => {
                     if let Some(index) =
                         whose_mouse(which, &app_state.players, app_state.player_count)
                     {
                         shoot(index, &mut app_state.players, app_state.player_count);
                     }
                 }
-                Event::KeyDown {
+                Event::Keyboard(KeyboardEvent {
                     keycode: Some(keycode),
                     which,
+                    state: KeyState::Down,
                     ..
-                } => {
+                }) => {
                     if let Some(index) =
                         whose_keyboard(which, &app_state.players, app_state.player_count)
                     {
@@ -659,11 +664,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         }
                     }
                 }
-                Event::KeyUp {
+                Event::Keyboard(KeyboardEvent {
                     keycode: Some(keycode),
                     which,
+                    state: KeyState::Up,
                     ..
-                } => {
+                }) => {
                     if keycode == Keycode::Escape {
                         break 'running;
                     }

--- a/examples/dialog.rs
+++ b/examples/dialog.rs
@@ -3,7 +3,7 @@ extern crate sdl3;
 use sdl3::dialog::{
     show_open_file_dialog, show_open_folder_dialog, show_save_file_dialog, DialogFileFilter,
 };
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent};
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::Color;
 use std::path::PathBuf;
@@ -47,17 +47,19 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => {
+                }) => {
                     break 'running;
                 }
-                Event::KeyDown {
+                Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::O),
+                    state: KeyState::Down,
                     ..
-                } => {
+                }) => {
                     show_open_file_dialog(
                         &filters,
                         None::<PathBuf>,
@@ -76,10 +78,11 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
                     )
                     .unwrap_or_else(|e| panic!("Failed to show open file dialog: {e}"));
                 }
-                Event::KeyDown {
+                Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::D),
+                    state: KeyState::Down,
                     ..
-                } => {
+                }) => {
                     show_open_folder_dialog(
                         Some(&default_path_path),
                         false,
@@ -96,10 +99,11 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
                         }),
                     );
                 }
-                Event::KeyDown {
+                Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::S),
+                    state: KeyState::Down,
                     ..
-                } => {
+                }) => {
                     show_save_file_dialog(
                         &filters,
                         Some("/home"),

--- a/examples/draw_triangle.rs
+++ b/examples/draw_triangle.rs
@@ -3,7 +3,12 @@
 extern crate sdl3;
 
 use sdl3::{
-    event::Event, keyboard::Keycode, pixels::Color, rect::Point, render::Canvas, video::Window,
+    event::{Event, KeyState, KeyboardEvent},
+    keyboard::Keycode,
+    pixels::Color,
+    rect::Point,
+    render::Canvas,
+    video::Window,
 };
 
 use std::time::Duration;
@@ -94,11 +99,12 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => break 'running,
+                }) => break 'running,
                 _ => {}
             }
         }

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent, MouseEvent};
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::Color;
 use std::time::Duration;
@@ -28,13 +28,14 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => break 'running,
+                }) => break 'running,
                 // skip mouse motion intentionally because of the verbose it might cause.
-                Event::MouseMotion { .. } => {}
+                Event::Mouse(MouseEvent::Motion { .. }) => {}
                 e => {
                     println!("{e:?}");
                 }

--- a/examples/game-of-life-unsafe-textures.rs
+++ b/examples/game-of-life-unsafe-textures.rs
@@ -3,7 +3,7 @@ extern crate sdl3;
 #[cfg(feature = "unsafe_textures")]
 use game_of_life::{PLAYGROUND_HEIGHT, PLAYGROUND_WIDTH, SQUARE_SIZE};
 #[cfg(feature = "unsafe_textures")]
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent};
 #[cfg(feature = "unsafe_textures")]
 use sdl3::keyboard::Keycode;
 #[cfg(feature = "unsafe_textures")]
@@ -254,16 +254,18 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         // get the inputs here
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => break 'running,
-                Event::KeyDown {
+                }) => break 'running,
+                Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Space),
+                    state: KeyState::Down,
                     repeat: false,
                     ..
-                } => {
+                }) => {
                     game.toggle_state();
                 }
                 Event::MouseButtonDown {

--- a/examples/game-of-life-unsafe-textures.rs
+++ b/examples/game-of-life-unsafe-textures.rs
@@ -3,7 +3,8 @@ extern crate sdl3;
 #[cfg(feature = "unsafe_textures")]
 use game_of_life::{PLAYGROUND_HEIGHT, PLAYGROUND_WIDTH, SQUARE_SIZE};
 #[cfg(feature = "unsafe_textures")]
-use sdl3::event::{Event, KeyState, KeyboardEvent};
+use sdl3::event::{Event, KeyState, KeyboardEvent, MouseButtonState, MouseEvent};
+
 #[cfg(feature = "unsafe_textures")]
 use sdl3::keyboard::Keycode;
 #[cfg(feature = "unsafe_textures")]
@@ -268,12 +269,13 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }) => {
                     game.toggle_state();
                 }
-                Event::MouseButtonDown {
+                Event::Mouse(MouseEvent::Button {
                     x,
                     y,
-                    mouse_btn: MouseButton::Left,
+                    button: MouseButton::Left,
+                    state: MouseButtonState::Down,
                     ..
-                } => {
+                }) => {
                     let x = (x as u32) / SQUARE_SIZE;
                     let y = (y as u32) / SQUARE_SIZE;
                     match game.get_mut(x as i32, y as i32) {

--- a/examples/game-of-life.rs
+++ b/examples/game-of-life.rs
@@ -2,7 +2,7 @@ extern crate sdl3;
 
 #[cfg(not(feature = "unsafe_textures"))]
 use crate::game_of_life::{PLAYGROUND_HEIGHT, PLAYGROUND_WIDTH, SQUARE_SIZE};
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent, MouseButtonState, MouseEvent};
 use sdl3::keyboard::Keycode;
 use sdl3::mouse::MouseButton;
 use sdl3::pixels::Color;
@@ -258,24 +258,27 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         // get the inputs here
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => break 'running,
-                Event::KeyDown {
+                }) => break 'running,
+                Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Space),
+                    state: KeyState::Down,
                     repeat: false,
                     ..
-                } => {
+                }) => {
                     game.toggle_state();
                 }
-                Event::MouseButtonDown {
+                Event::Mouse(MouseEvent::Button {
                     x,
                     y,
-                    mouse_btn: MouseButton::Left,
+                    button: MouseButton::Left,
+                    state: MouseButtonState::Down,
                     ..
-                } => {
+                }) => {
                     let x = (x as u32) / SQUARE_SIZE;
                     let y = (y as u32) / SQUARE_SIZE;
                     match game.get_mut(x as i32, y as i32) {

--- a/examples/gfx-demo.rs
+++ b/examples/gfx-demo.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent, MouseButtonState, MouseEvent};
 use sdl3::keyboard::Keycode;
 use sdl3::pixels;
 
@@ -37,12 +37,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     'main: loop {
         for event in events.poll_iter() {
             match event {
-                Event::Quit { .. } => break 'main,
+                Event::Quit(_) => break 'main,
 
-                Event::KeyDown {
+                Event::Keyboard(KeyboardEvent {
                     keycode: Some(keycode),
+                    state: KeyState::Down,
                     ..
-                } => {
+                }) => {
                     if keycode == Keycode::Escape {
                         break 'main;
                     } else if keycode == Keycode::Space {
@@ -54,7 +55,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
 
-                Event::MouseButtonDown { x, y, .. } => {
+                Event::Mouse(MouseEvent::Button {
+                    x,
+                    y,
+                    state: MouseButtonState::Down,
+                    ..
+                }) => {
                     let color = pixels::Color::RGB(x as u8, y as u8, 255);
                     let _ = canvas.line(lastx, lasty, x as i16, y as i16, color);
                     lastx = x as i16;

--- a/examples/gpu-clear.rs
+++ b/examples/gpu-clear.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent};
 use sdl3::keyboard::Keycode;
 
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -26,11 +26,12 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => break 'running,
+                }) => break 'running,
                 _ => {}
             }
         }

--- a/examples/gpu-cube.rs
+++ b/examples/gpu-cube.rs
@@ -1,5 +1,5 @@
 use sdl3::{
-    event::Event,
+    event::{Event, KeyState, KeyboardEvent},
     gpu::{
         Buffer, BufferBinding, BufferRegion, BufferUsageFlags, ColorTargetDescription,
         ColorTargetInfo, CompareOp, CopyPass, CullMode, DepthStencilState, DepthStencilTargetInfo,
@@ -219,11 +219,12 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => break 'running,
+                }) => break 'running,
                 _ => {}
             }
         }

--- a/examples/gpu-particles.rs
+++ b/examples/gpu-particles.rs
@@ -1,7 +1,10 @@
 use rand::Rng;
 use sdl3::gpu::*;
 use sdl3::pixels::Color;
-use sdl3::{event::Event, keyboard::Keycode};
+use sdl3::{
+    event::{Event, KeyState, KeyboardEvent},
+    keyboard::Keycode,
+};
 use std::mem::size_of;
 
 #[repr(C)]
@@ -119,11 +122,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     'running: loop {
         for e in events.poll_iter() {
             match e {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => break 'running,
+                }) => break 'running,
                 _ => {}
             }
         }

--- a/examples/gpu-texture.rs
+++ b/examples/gpu-texture.rs
@@ -1,5 +1,5 @@
 use sdl3::{
-    event::Event,
+    event::{Event, KeyState, KeyboardEvent},
     gpu::{
         Buffer, BufferBinding, BufferRegion, BufferUsageFlags, ColorTargetDescription,
         ColorTargetInfo, CompareOp, CopyPass, CullMode, DepthStencilState, DepthStencilTargetInfo,
@@ -346,11 +346,12 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => break 'running,
+                }) => break 'running,
                 _ => {}
             }
         }

--- a/examples/gpu-triangle.rs
+++ b/examples/gpu-triangle.rs
@@ -1,7 +1,7 @@
 extern crate sdl3;
 
 use sdl3::{
-    event::Event,
+    event::{Event, KeyState, KeyboardEvent},
     gpu::{
         ColorTargetDescription, ColorTargetInfo, Device, FillMode, GraphicsPipelineTargetInfo,
         LoadOp, PrimitiveType, ShaderFormat, ShaderStage, StoreOp,
@@ -75,11 +75,12 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => break 'running,
+                }) => break 'running,
                 _ => {}
             }
         }

--- a/examples/image-demo.rs
+++ b/examples/image-demo.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent, MouseButtonState, MouseEvent};
 use sdl3::image::LoadTexture;
 use sdl3::keyboard::Keycode;
 use std::env;
@@ -25,11 +25,12 @@ pub fn run(png: &Path) -> Result<(), Box<dyn std::error::Error>> {
     'mainloop: loop {
         for event in sdl_context.event_pump()?.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
-                    keycode: Option::Some(Keycode::Escape),
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
+                    keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => break 'mainloop,
+                }) => break 'mainloop,
                 _ => {}
             }
         }

--- a/examples/keyboard-state.rs
+++ b/examples/keyboard-state.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent};
 use sdl3::keyboard::Keycode;
 use sdl3_sys::keycode::SDL_KMOD_NONE;
 use std::collections::HashSet;
@@ -22,9 +22,15 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     'running: loop {
         for event in events.poll_iter() {
-            if let Event::Quit { .. } = event {
-                break 'running;
-            };
+            match event {
+                Event::Quit(_) => break 'running,
+                Event::Keyboard(KeyboardEvent {
+                    state: KeyState::Down,
+                    keycode: Some(Keycode::Escape),
+                    ..
+                }) => break 'running,
+                _ => {}
+            }
         }
 
         // Create a set of pressed Keys.

--- a/examples/message-box.rs
+++ b/examples/message-box.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent};
 use sdl3::keyboard::Keycode;
 use sdl3::messagebox::*;
 use sdl3::pixels::Color;
@@ -26,11 +26,12 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => {
+                }) => {
                     show_simple_message_box(
                         MessageBoxFlag::ERROR,
                         "Some title",

--- a/examples/mouse-state.rs
+++ b/examples/mouse-state.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent};
 use sdl3::keyboard::Keycode;
 use std::collections::HashSet;
 use std::time::Duration;
@@ -22,11 +22,12 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     'running: loop {
         for event in events.poll_iter() {
             match event {
-                Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                }
-                | Event::Quit { .. } => break 'running,
+                }) => break 'running,
                 _ => {}
             }
         }

--- a/examples/no-renderer.rs
+++ b/examples/no-renderer.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent};
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::Color;
 use sdl3::rect::Rect;
@@ -68,12 +68,17 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut keypress: bool = false;
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => break 'running,
-                Event::KeyDown { repeat: false, .. } => {
+                }) => break 'running,
+                Event::Keyboard(KeyboardEvent {
+                    state: KeyState::Down,
+                    repeat: false,
+                    ..
+                }) => {
                     keypress = true;
                 }
                 _ => {}

--- a/examples/raw-window-handle-with-wgpu/main.rs
+++ b/examples/raw-window-handle-with-wgpu/main.rs
@@ -7,7 +7,7 @@ extern crate wgpu;
 use std::borrow::Cow;
 use wgpu::{InstanceDescriptor, SurfaceError};
 
-use sdl3::event::{Event, WindowEvent, WindowEventKind};
+use sdl3::event::{Event, KeyState, KeyboardEvent, WindowEvent, WindowEventKind};
 use sdl3::keyboard::Keycode;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -130,22 +130,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Event::Window(WindowEvent {
                     window_id,
                     kind:
-                        WindowEventKind::PixelSizeChanged(width, height)
-                        | WindowEventKind::Resized(width, height),
+                        WindowEventKind::PixelSizeChanged { w, h } | WindowEventKind::Resized { w, h },
                     ..
                 }) if window_id == window.id() => {
-                    config.width = width as u32;
-                    config.height = height as u32;
+                    config.width = w as u32;
+                    config.height = h as u32;
                     surface.configure(&device, &config);
                 }
                 Event::Quit(_)
                 | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
                     state: KeyState::Down,
+                    repeat: false,
                     ..
-                }) => {
-                    break 'running;
-                }
+                }) => break 'running,
                 e => {
                     dbg!(e);
                 }

--- a/examples/raw-window-handle-with-wgpu/main.rs
+++ b/examples/raw-window-handle-with-wgpu/main.rs
@@ -7,7 +7,7 @@ extern crate wgpu;
 use std::borrow::Cow;
 use wgpu::{InstanceDescriptor, SurfaceError};
 
-use sdl3::event::{Event, WindowEvent};
+use sdl3::event::{Event, WindowEvent, WindowEventKind};
 use sdl3::keyboard::Keycode;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -127,22 +127,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Window {
+                Event::Window(WindowEvent {
                     window_id,
-                    win_event:
-                        WindowEvent::PixelSizeChanged(width, height)
-                        | WindowEvent::Resized(width, height),
+                    kind:
+                        WindowEventKind::PixelSizeChanged(width, height)
+                        | WindowEventKind::Resized(width, height),
                     ..
-                } if window_id == window.id() => {
+                }) if window_id == window.id() => {
                     config.width = width as u32;
                     config.height = height as u32;
                     surface.configure(&device, &config);
                 }
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => {
+                }) => {
                     break 'running;
                 }
                 e => {

--- a/examples/relative-mouse-state.rs
+++ b/examples/relative-mouse-state.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent};
 use sdl3::keyboard::Keycode;
 use sdl3::mouse::MouseButton;
 use std::time::Duration;
@@ -21,11 +21,12 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     'running: loop {
         for event in events.poll_iter() {
             match event {
-                Event::KeyDown {
+                Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                }
-                | Event::Quit { .. } => break 'running,
+                })
+                | Event::Quit(_) => break 'running,
                 _ => {}
             }
         }

--- a/examples/render-geometry.rs
+++ b/examples/render-geometry.rs
@@ -1,4 +1,4 @@
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent};
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::{Color, FColor};
 use sdl3::render::{FPoint, RenderGeometryTextureParams, Vertex, VertexIndices};
@@ -25,11 +25,12 @@ fn main() {
     while running {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => {
+                }) => {
                     running = false;
                 }
                 _ => {}

--- a/examples/renderer-target.rs
+++ b/examples/renderer-target.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent};
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::{Color, PixelFormat};
 use sdl3::render::{FPoint, FRect};
@@ -29,11 +29,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     'mainloop: loop {
         for event in sdl_context.event_pump()?.poll_iter() {
             match event {
-                Event::KeyDown {
+                Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                }
-                | Event::Quit { .. } => break 'mainloop,
+                })
+                | Event::Quit(_) => break 'mainloop,
                 _ => {}
             }
         }

--- a/examples/renderer-texture.rs
+++ b/examples/renderer-texture.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent};
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::PixelFormat;
 use sdl3::render::FRect;
@@ -57,11 +57,12 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => break 'running,
+                }) => break 'running,
                 _ => {}
             }
         }

--- a/examples/renderer-yuv.rs
+++ b/examples/renderer-yuv.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent};
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::PixelFormat;
 use sdl3::render::FRect;
@@ -65,11 +65,12 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => break 'running,
+                }) => break 'running,
                 _ => {}
             }
         }

--- a/examples/resource-manager.rs
+++ b/examples/resource-manager.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent};
 use sdl3::image::{InitFlag, LoadTexture};
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::Color;
@@ -47,11 +47,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         'mainloop: loop {
             for event in sdl_context.event_pump()?.poll_iter() {
                 match event {
-                    Event::KeyDown {
+                    Event::Quit(_)
+                    | Event::Keyboard(KeyboardEvent {
                         keycode: Some(Keycode::Escape),
+                        state: KeyState::Down,
                         ..
-                    }
-                    | Event::Quit { .. } => break 'mainloop,
+                    }) => break 'mainloop,
                     _ => {}
                 }
             }

--- a/examples/sensors.rs
+++ b/examples/sensors.rs
@@ -1,7 +1,10 @@
 extern crate sdl3;
 use std::time::{Duration, Instant};
 
-use sdl3::{event::Event, sensor::SensorType};
+use sdl3::{
+    event::{ControllerEvent, Event},
+    sensor::SensorType,
+};
 
 fn main() -> Result<(), String> {
     let sdl_context = sdl3::init().unwrap();
@@ -79,11 +82,11 @@ fn main() -> Result<(), String> {
             println!("gyro: {:?}, accel: {:?}", gyro_data, accel_data);
         }
 
-        if let Event::ControllerSensorUpdated { .. } = event {
+        if let Event::Controller(ControllerEvent::Sensor { .. }) = event {
             println!("{:?}", event);
         }
 
-        if let Event::Quit { .. } = event {
+        if let Event::Quit(_) = event {
             break;
         }
     }

--- a/examples/spinning_cube.rs
+++ b/examples/spinning_cube.rs
@@ -6,7 +6,12 @@
 extern crate sdl3;
 
 use sdl3::{
-    event::Event, keyboard::Keycode, pixels::Color, rect::Point, render::Canvas, video::Window,
+    event::{Event, KeyState, KeyboardEvent},
+    keyboard::Keycode,
+    pixels::Color,
+    rect::Point,
+    render::Canvas,
+    video::Window,
 };
 use std::time::Duration;
 
@@ -127,11 +132,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => {
+                }) => {
                     break 'running;
                 }
                 _ => {}

--- a/examples/ttf-demo.rs
+++ b/examples/ttf-demo.rs
@@ -3,7 +3,7 @@ extern crate sdl3;
 use std::env;
 use std::path::Path;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent};
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::Color;
 use sdl3::rect::Rect;
@@ -91,10 +91,11 @@ fn run(font_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     'mainloop: loop {
         for event in sdl_context.event_pump()?.poll_iter() {
             match event {
-                Event::KeyDown {
+                Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                }
+                })
                 | Event::Quit { .. } => break 'mainloop,
                 _ => {}
             }

--- a/examples/window-properties.rs
+++ b/examples/window-properties.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::event::Event;
+use sdl3::event::{Event, KeyState, KeyboardEvent};
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::Color;
 
@@ -28,11 +28,12 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     'running: loop {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
+                Event::Quit(_)
+                | Event::Keyboard(KeyboardEvent {
                     keycode: Some(Keycode::Escape),
+                    state: KeyState::Down,
                     ..
-                } => break 'running,
+                }) => break 'running,
                 _ => {}
             }
         }

--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -1248,7 +1248,7 @@ impl Event {
                         e.r#type = SDL_EventType(EventType::ControllerSensorUpdated as u32);
                         e.timestamp = *timestamp;
                         e.which = *which;
-                        e.sensor = sensor.into_raw();
+                        e.sensor = sensor.to_ll().0;
                         e.data = *data;
                         ptr::copy(
                             &e,

--- a/src/sdl3/keyboard/keycode.rs
+++ b/src/sdl3/keyboard/keycode.rs
@@ -523,7 +523,7 @@ impl Keycode {
     }
 
     pub fn to_ll(self) -> SDL_Keycode {
-        unsafe { i32::cast_unsigned(self as i32) }
+        i32::cast_unsigned(self as i32)
     }
 }
 

--- a/src/sdl3/pen.rs
+++ b/src/sdl3/pen.rs
@@ -36,4 +36,8 @@ impl PenAxis {
             _ => PenAxis::Unknown,
         }
     }
+    #[inline]
+    pub fn to_ll(self) -> sys::pen::SDL_PenAxis {
+        sys::pen::SDL_PenAxis(self as i32)
+    }
 }

--- a/src/sdl3/sensor.rs
+++ b/src/sdl3/sensor.rs
@@ -96,6 +96,12 @@ impl SensorType {
             _ => SensorType::Unknown,
         }
     }
+
+    /// Convert the high-level SensorType into its low-level SDL_SensorType.
+    #[inline]
+    pub fn to_ll(self) -> SDL_SensorType {
+        self.into()
+    }
 }
 
 impl Into<SDL_SensorType> for SensorType {


### PR DESCRIPTION
Hi, while using migrating from winit to SDL3, I noticed that some of the events strangely did not have all of the correct fields and names (In my particular case, I have multiple windows and many of the events were missing `window_id`).

Seeing as some of these events haven't been updates in years from their source, I went ahead and modernized the events a bit. Thankfully, as you can see in the examples, their replacement/updated usage is pretty easy to follow.

Key changes:
- Group related raw SDL events under category enums (Window, Keyboard, Mouse, Joystick, Controller, etc.).
- Preserve ability to convert to/from raw `SDL_Event` (where feasible).
- Keep the name `Event` so external code continues to reference `crate::event::Event`.
- Maintain custom/user event registration and pushing.
- Provide helper methods analogous to the old API (`get_timestamp`, `get_window_id`, `is_*` classifiers).