### PR TITLE
feat(raw_window_handle): Improve raw-window-handle api & bump wgpu version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c239a9a747bbd379590985bac952c2e53cb19873f7072b3370c6a6a8e06837"
+checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
 dependencies = [
  "arrayvec",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "29.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c239a9a747bbd379590985bac952c2e53cb19873f7072b3370c6a6a8e06837"
+checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
 dependencies = [
  "arrayvec",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bit-set"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
 dependencies = [
  "bit-vec",
 ]
@@ -405,26 +405,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-descriptor"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
-dependencies = [
- "bitflags",
- "gpu-descriptor-types",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "gpu-descriptor-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,16 +437,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hexf-parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "id-arena"
@@ -614,9 +597,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "naga"
-version = "29.0.1"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2630921705b9b01dcdd0b6864b9562ca3c1951eecd0f0c4f5f04f61e412647"
+checksum = "23bf0a141a9ab6f07dbb492db53245e464bc9db42f407772d9ae03d83a2c1033"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -625,11 +608,11 @@ dependencies = [
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown 0.16.0",
- "hexf-parse",
+ "hashbrown 0.17.1",
  "indexmap",
  "libm",
  "log",
+ "naga-types",
  "num-traits",
  "once_cell",
  "petgraph",
@@ -637,6 +620,18 @@ dependencies = [
  "spirv",
  "thiserror",
  "unicode-ident",
+]
+
+[[package]]
+name = "naga-types"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658200ddc25c6c7b860747516d132d1b284c0fafb7a380233acee9a72fb30e11"
+dependencies = [
+ "hashbrown 0.17.1",
+ "indexmap",
+ "rustc-hash",
+ "thiserror",
 ]
 
 [[package]]
@@ -679,6 +674,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +696,17 @@ name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags",
  "objc2",
@@ -716,6 +734,7 @@ dependencies = [
  "bitflags",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "objc2-metal",
 ]
@@ -1378,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "29.0.3"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
+checksum = "6d8f4bd44d92da5270f03409dba9f952dab24f128e05d6a554926101d1bf9114"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -1388,7 +1407,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.16.0",
+ "hashbrown 0.17.1",
  "js-sys",
  "log",
  "naga",
@@ -1408,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "29.0.1"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e80ac6cf1895df6342f87d975162108f9d98772a0d74bc404ab7304ac29469e"
+checksum = "08763620e76fc980bca7bf84de82568614487a53172dd968d89187282eb87fa2"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -1419,10 +1438,11 @@ dependencies = [
  "bytemuck",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.16.0",
+ "hashbrown 0.17.1",
  "indexmap",
  "log",
  "naga",
+ "naga-types",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -1441,36 +1461,36 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43acd053312501689cd92a01a9638d37f3e41a5fd9534875efa8917ee2d11ac0"
+checksum = "3283b6da70d7fc892de95840215aa36381b5d0cbc479e88ee2b173c7b992b225"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef043bf135cc68b6f667c55ff4e345ce2b5924d75bad36a47921b0287ca4b24a"
+checksum = "85dcf2b2e5c2afb9eda64c570a87a4e570304bf39e52eddbaaf222d655b656ad"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725d5c006a8c02967b6d93ef04f6537ec4593313e330cfe86d9d3f946eb90f28"
+checksum = "f76bc9c1c186ff3d9054e0d224c93c8c1c79d6653907c5249a5c1ea1a2cb1e43"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "29.0.1"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a47aef47636562f3937285af4c44b4b5b404b46577471411cc5313a921da7e"
+checksum = "cf765132d8d5f50e192e7880464890c13f4e7457aafe8e5466e8174586e9f101"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -1484,17 +1504,18 @@ dependencies = [
  "glow",
  "glutin_wgl_sys",
  "gpu-allocator",
- "gpu-descriptor",
- "hashbrown 0.16.0",
+ "hashbrown 0.17.1",
  "js-sys",
  "khronos-egl",
  "libc",
  "libloading",
  "log",
  "naga",
+ "naga-types",
  "ndk-sys",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "objc2-metal",
  "objc2-quartz-core",
@@ -1509,6 +1530,7 @@ dependencies = [
  "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
+ "static_assertions",
  "thiserror",
  "wasm-bindgen",
  "wayland-sys",
@@ -1517,13 +1539,14 @@ dependencies = [
  "wgpu-types",
  "windows",
  "windows-core",
+ "windows-result",
 ]
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.1"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4684f4410da0cf95a4cb63bb5edaac022461dedb6adf0b64d0d9b5f6890d51"
+checksum = "c9eaac644e5008925c78567d272b9d66ef83da55a53cc17fc7daade7bb6e66e5"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -1531,15 +1554,17 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.1"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2675540fb1a5cfa5ef122d3d5f390e2c75711a0b946410f2d6ac3a0f77d1f6"
+checksum = "1a9c93c2b35edde326df60ffdee4c0f5864eac3011d6768b70d43f028ad93565"
 dependencies = [
  "bitflags",
  "bytemuck",
  "js-sys",
  "log",
+ "naga-types",
  "raw-window-handle",
+ "static_assertions",
  "web-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ build-from-source-static = [
 ]
 build-from-source-unix-console = ["sdl3-sys/sdl-unix-console-build"]
 ash = ["sdl3-sys/use-ash-v0-38"]
-default = []
+default = ["raw-window-handle"]
 unsafe_textures = []
 # DEPRECATED: gfx feature is non-functional - SDL_gfx has not been ported to SDL3 yet.
 # See: https://github.com/vhspace/sdl3-rs/issues/160

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ optional = true
 
 [dev-dependencies]
 rand = "0.10.1"
-wgpu = { version = "29.0.3", features = ["spirv"] }
+wgpu = { version = "30.0.0", features = ["spirv"] }
 pollster = "0.4.0"
 env_logger = "0.11.10"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ optional = true
 
 [dev-dependencies]
 rand = "0.10.1"
-wgpu = { version = "29.0.1", features = ["spirv"] }
+wgpu = { version = "29.0.3", features = ["spirv"] }
 pollster = "0.4.0"
 env_logger = "0.11.10"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ optional = true
 
 [dev-dependencies]
 rand = "0.10.1"
-wgpu = { version = "29.0.1", features = ["spirv"] }
+wgpu = { version = "29.0.3", features = ["spirv"] }
 pollster = "0.4.0"
 env_logger = "0.11.10"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ build-from-source-static = [
 ]
 build-from-source-unix-console = ["sdl3-sys/sdl-unix-console-build"]
 ash = ["sdl3-sys/use-ash-v0-38"]
-default = ["raw-window-handle"]
+default = []
 unsafe_textures = []
 # DEPRECATED: gfx feature is non-functional - SDL_gfx has not been ported to SDL3 yet.
 # See: https://github.com/vhspace/sdl3-rs/issues/160

--- a/examples/raw-window-handle-with-wgpu/main.rs
+++ b/examples/raw-window-handle-with-wgpu/main.rs
@@ -28,6 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         power_preference: wgpu::PowerPreference::HighPerformance,
         force_fallback_adapter: false,
         compatible_surface: Some(&surface),
+		apply_limit_buckets: false,
     }))?;
 
     let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
@@ -107,6 +108,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut config = wgpu::SurfaceConfiguration {
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         format: main_format,
+		color_space: wgpu::SurfaceColorSpace::Auto,
         width,
         height,
         present_mode: wgpu::PresentMode::Fifo,
@@ -185,7 +187,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             rpass.draw(0..3, 0..1);
         }
         queue.submit(std::iter::once(encoder.finish()));
-        frame.present();
+		queue.present(frame);
     }
 
     Ok(())

--- a/examples/raw-window-handle-with-wgpu/main.rs
+++ b/examples/raw-window-handle-with-wgpu/main.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
-    let window = video_subsystem
+    let mut window = video_subsystem
         .window("Raw Window Handle Example", 800, 600)
         .position_centered()
         .resizable()
@@ -21,7 +21,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (width, height) = window.size();
 
     let instance = wgpu::Instance::new(InstanceDescriptor::new_without_display_handle_from_env());
-    let surface = instance.create_surface(window.as_window_handle()?)?;
+    let (window, window_handle) = window.mut_as_window_handle()?; // reassigning `window` here allows for mutating the window (with methods such as `window.show()`) while still having a lifetime-bounded handle for it
+    let surface = instance.create_surface(window_handle)?;
     let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::HighPerformance,
         force_fallback_adapter: false,

--- a/examples/raw-window-handle-with-wgpu/main.rs
+++ b/examples/raw-window-handle-with-wgpu/main.rs
@@ -17,12 +17,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .position_centered()
         .resizable()
         .metal_view()
-        .build()
-        .map_err(|e| e.to_string())?;
+        .build()?;
     let (width, height) = window.size();
 
     let instance = wgpu::Instance::new(InstanceDescriptor::new_without_display_handle_from_env());
-    let surface = create_surface::create_surface(&instance, &window)?;
+    let surface = instance.create_surface(window.as_window_handle()?)?;
     let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::HighPerformance,
         force_fallback_adapter: false,
@@ -188,35 +187,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
-}
-
-mod create_surface {
-    use sdl3::video::Window;
-    use wgpu::rwh::{HasDisplayHandle, HasWindowHandle};
-
-    // contains the unsafe impl as much as possible by putting it in this module
-    struct SyncWindow<'a>(&'a Window);
-
-    unsafe impl<'a> Send for SyncWindow<'a> {}
-    unsafe impl<'a> Sync for SyncWindow<'a> {}
-
-    impl<'a> HasWindowHandle for SyncWindow<'a> {
-        fn window_handle(&self) -> Result<wgpu::rwh::WindowHandle<'_>, wgpu::rwh::HandleError> {
-            self.0.window_handle()
-        }
-    }
-    impl<'a> HasDisplayHandle for SyncWindow<'a> {
-        fn display_handle(&self) -> Result<wgpu::rwh::DisplayHandle<'_>, wgpu::rwh::HandleError> {
-            self.0.display_handle()
-        }
-    }
-
-    pub fn create_surface<'a>(
-        instance: &wgpu::Instance,
-        window: &'a Window,
-    ) -> Result<wgpu::Surface<'a>, String> {
-        instance
-            .create_surface(SyncWindow(&window))
-            .map_err(|err| err.to_string())
-    }
 }

--- a/examples/raw-window-handle-with-wgpu/main.rs
+++ b/examples/raw-window-handle-with-wgpu/main.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         power_preference: wgpu::PowerPreference::HighPerformance,
         force_fallback_adapter: false,
         compatible_surface: Some(&surface),
-		apply_limit_buckets: false,
+        apply_limit_buckets: false,
     }))?;
 
     let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
@@ -108,7 +108,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut config = wgpu::SurfaceConfiguration {
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         format: main_format,
-		color_space: wgpu::SurfaceColorSpace::Auto,
+        color_space: wgpu::SurfaceColorSpace::Auto,
         width,
         height,
         present_mode: wgpu::PresentMode::Fifo,
@@ -187,7 +187,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             rpass.draw(0..3, 0..1);
         }
         queue.submit(std::iter::once(encoder.finish()));
-		queue.present(frame);
+        queue.present(frame);
     }
 
     Ok(())

--- a/examples/raw-window-handle-with-wgpu/main.rs
+++ b/examples/raw-window-handle-with-wgpu/main.rs
@@ -21,7 +21,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (width, height) = window.size();
 
     let instance = wgpu::Instance::new(InstanceDescriptor::new_without_display_handle_from_env());
-    let (window, window_handle) = window.mut_as_window_handle()?; // reassigning `window` here allows for mutating the window (with methods such as `window.show()`) while still having a lifetime-bounded handle for it
+    let (window, window_handle) = window.as_window_handles_mut()?; // reassigning `window` here allows for mutating the window (with methods such as `window.show()`) while still having a lifetime-bounded handle for it
+    window.show();
     let surface = instance.create_surface(window_handle)?;
     let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::HighPerformance,

--- a/src/sdl3/raw_window_handle.rs
+++ b/src/sdl3/raw_window_handle.rs
@@ -1,7 +1,10 @@
 extern crate raw_window_handle;
 
 use crate::video::Window;
-use raw_window_handle::{DisplayHandle, HandleError, HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle, WindowHandle};
+use raw_window_handle::{
+    DisplayHandle, HandleError, HasDisplayHandle, HasWindowHandle, RawDisplayHandle,
+    RawWindowHandle, WindowHandle,
+};
 use std::{ffi::CStr, num::NonZero, ptr::NonNull};
 use sys::properties::{SDL_GetNumberProperty, SDL_GetPointerProperty};
 

--- a/src/sdl3/raw_window_handle.rs
+++ b/src/sdl3/raw_window_handle.rs
@@ -6,10 +6,11 @@ use raw_window_handle::{
     RawWindowHandle, WindowHandle,
 };
 use std::{ffi::CStr, num::NonZero, ptr::NonNull};
-use sys::properties::{SDL_GetNumberProperty, SDL_GetPointerProperty};
+use sys::{properties::{SDL_GetNumberProperty, SDL_GetPointerProperty}, video::SDL_Window};
 
 // this queries then stores all handles upon creation, then returns the stored values on request
 
+#[derive(Debug, PartialEq)]
 pub struct WindowAsWindowHandle<'a> {
     window_handle: WindowHandle<'a>,
     display_handle: DisplayHandle<'a>,
@@ -31,22 +32,32 @@ impl<'a> HasDisplayHandle for WindowAsWindowHandle<'a> {
 }
 
 impl Window {
+    /// Gives a window handle that can be used by crates like wgpu, glutin, etc. Note: using this function means you cannot use methods on `sdl3::video::Window` which take `&mut Self` (such as `window.show()`, `window.minimize()`, etc), if you need to these functions then use `Window::mut_as_window_handle()` instead.
     pub fn as_window_handle<'a>(&'a self) -> Result<WindowAsWindowHandle<'a>, HandleError> {
         Ok(WindowAsWindowHandle {
-            window_handle: window_handle(self)?,
-            display_handle: display_handle(self)?,
+            window_handle: window_handle(self.raw())?,
+            display_handle: display_handle(self.raw())?,
         })
+    }
+	// Safety: this does break rust's safety rule that you cannot modify something while there are other references to it, but following that rule religiously here would do more harm than good
+    /// Gives a window handle that can be used by crates like wgpu, glutin, etc. Unlike `Window::as_window_handle()`, this gives back a mutable reference which can be used for methods which take `&mut Self` (such as `window.show()`, `window.minimize()`, etc)
+    pub fn mut_as_window_handle<'a>(&'a mut self) -> Result<(&'a mut Self, WindowAsWindowHandle<'a>), HandleError> {
+        let handle = WindowAsWindowHandle {
+            window_handle: window_handle(self.raw())?,
+            display_handle: display_handle(self.raw())?,
+        };
+        Ok((self, handle))
     }
 }
 
 // Access window handle using SDL3 properties
-fn window_handle<'a>(window: &'a Window) -> Result<WindowHandle<'a>, HandleError> {
+fn window_handle<'a>(raw_window: *mut SDL_Window) -> Result<WindowHandle<'a>, HandleError> {
     // Windows
     #[cfg(target_os = "windows")]
     unsafe {
-        use self::raw_window_handle::Win32WindowHandle;
+        use raw_window_handle::Win32WindowHandle;
 
-        let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
+        let window_properties = sys::video::SDL_GetWindowProperties(raw_window);
 
         let hwnd = SDL_GetPointerProperty(
             window_properties,
@@ -68,10 +79,10 @@ fn window_handle<'a>(window: &'a Window) -> Result<WindowHandle<'a>, HandleError
     // macOS
     #[cfg(target_os = "macos")]
     unsafe {
-        use self::raw_window_handle::AppKitWindowHandle;
+        use raw_window_handle::AppKitWindowHandle;
         use objc2::{msg_send, runtime::NSObject};
 
-        let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
+        let window_properties = sys::video::SDL_GetWindowProperties(raw_window);
 
         let ns_window = SDL_GetPointerProperty(
             window_properties,
@@ -91,9 +102,9 @@ fn window_handle<'a>(window: &'a Window) -> Result<WindowHandle<'a>, HandleError
     // iOS
     #[cfg(target_os = "ios")]
     unsafe {
-        use self::raw_window_handle::UiKitWindowHandle;
+        use raw_window_handle::UiKitWindowHandle;
 
-        let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
+        let window_properties = sys::video::SDL_GetWindowProperties(raw_window);
 
         let ui_view = SDL_GetPointerProperty(
             window_properties,
@@ -109,9 +120,9 @@ fn window_handle<'a>(window: &'a Window) -> Result<WindowHandle<'a>, HandleError
     // Android
     #[cfg(target_os = "android")]
     unsafe {
-        use self::raw_window_handle::AndroidNdkWindowHandle;
+        use raw_window_handle::AndroidNdkWindowHandle;
 
-        let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
+        let window_properties = sys::video::SDL_GetWindowProperties(raw_window);
 
         let native_window = SDL_GetPointerProperty(
             window_properties,
@@ -136,9 +147,9 @@ fn window_handle<'a>(window: &'a Window) -> Result<WindowHandle<'a>, HandleError
 
         match video_driver.to_bytes() {
             b"x11" => {
-                use self::raw_window_handle::XlibWindowHandle;
+                use raw_window_handle::XlibWindowHandle;
 
-                let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
+                let window_properties = sys::video::SDL_GetWindowProperties(raw_window);
 
                 let window = SDL_GetNumberProperty(
                     window_properties,
@@ -151,9 +162,9 @@ fn window_handle<'a>(window: &'a Window) -> Result<WindowHandle<'a>, HandleError
                 Ok(WindowHandle::borrow_raw(raw_window_handle))
             }
             b"wayland" => {
-                use self::raw_window_handle::WaylandWindowHandle;
+                use raw_window_handle::WaylandWindowHandle;
 
-                let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
+                let window_properties = sys::video::SDL_GetWindowProperties(raw_window);
 
                 let window = SDL_GetPointerProperty(
                     window_properties,
@@ -173,11 +184,11 @@ fn window_handle<'a>(window: &'a Window) -> Result<WindowHandle<'a>, HandleError
 }
 
 // Access display handle using SDL3 properties
-fn display_handle<'a>(window: &'a Window) -> Result<DisplayHandle<'a>, HandleError> {
+fn display_handle<'a>(raw_window: *mut SDL_Window) -> Result<DisplayHandle<'a>, HandleError> {
     // Windows
     #[cfg(target_os = "windows")]
     unsafe {
-        use self::raw_window_handle::WindowsDisplayHandle;
+        use raw_window_handle::WindowsDisplayHandle;
         let handle = WindowsDisplayHandle::new();
         let raw_window_handle = RawDisplayHandle::Windows(handle);
 
@@ -187,7 +198,7 @@ fn display_handle<'a>(window: &'a Window) -> Result<DisplayHandle<'a>, HandleErr
     // macOS
     #[cfg(target_os = "macos")]
     unsafe {
-        use self::raw_window_handle::AppKitDisplayHandle;
+        use raw_window_handle::AppKitDisplayHandle;
         let handle = AppKitDisplayHandle::new();
         let raw_window_handle = RawDisplayHandle::AppKit(handle);
 
@@ -197,7 +208,7 @@ fn display_handle<'a>(window: &'a Window) -> Result<DisplayHandle<'a>, HandleErr
     // iOS
     #[cfg(target_os = "ios")]
     unsafe {
-        use self::raw_window_handle::UiKitDisplayHandle;
+        use raw_window_handle::UiKitDisplayHandle;
         let handle = UiKitDisplayHandle::new();
         let raw_window_handle = RawDisplayHandle::UiKit(handle);
 
@@ -207,7 +218,7 @@ fn display_handle<'a>(window: &'a Window) -> Result<DisplayHandle<'a>, HandleErr
     // Android
     #[cfg(target_os = "android")]
     unsafe {
-        use self::raw_window_handle::AndroidDisplayHandle;
+        use raw_window_handle::AndroidDisplayHandle;
         let handle = AndroidDisplayHandle::new();
         let raw_window_handle = RawDisplayHandle::Android(handle);
 
@@ -226,9 +237,9 @@ fn display_handle<'a>(window: &'a Window) -> Result<DisplayHandle<'a>, HandleErr
 
         match video_driver.to_bytes() {
             b"x11" => {
-                use self::raw_window_handle::XlibDisplayHandle;
+                use raw_window_handle::XlibDisplayHandle;
 
-                let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
+                let window_properties = sys::video::SDL_GetWindowProperties(raw_window);
 
                 let display = SDL_GetPointerProperty(
                     window_properties,
@@ -248,9 +259,9 @@ fn display_handle<'a>(window: &'a Window) -> Result<DisplayHandle<'a>, HandleErr
                 Ok(DisplayHandle::borrow_raw(raw_window_handle))
             }
             b"wayland" => {
-                use self::raw_window_handle::WaylandDisplayHandle;
+                use raw_window_handle::WaylandDisplayHandle;
 
-                let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
+                let window_properties = sys::video::SDL_GetWindowProperties(raw_window);
 
                 let display = SDL_GetPointerProperty(
                     window_properties,

--- a/src/sdl3/raw_window_handle.rs
+++ b/src/sdl3/raw_window_handle.rs
@@ -1,246 +1,270 @@
 extern crate raw_window_handle;
 
-use self::raw_window_handle::{
-    DisplayHandle, HandleError, HasDisplayHandle, HasWindowHandle, RawWindowHandle, WindowHandle,
-};
 use crate::video::Window;
-use raw_window_handle::RawDisplayHandle;
+use raw_window_handle::{DisplayHandle, HandleError, HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle, WindowHandle};
 use std::{ffi::CStr, num::NonZero, ptr::NonNull};
 use sys::properties::{SDL_GetNumberProperty, SDL_GetPointerProperty};
 
+// this queries then stores all handles upon creation, then returns the stored values on request
+
+pub struct WindowAsWindowHandle<'a> {
+	window_handle: WindowHandle<'a>,
+	display_handle: DisplayHandle<'a>,
+}
+
+unsafe impl<'a> Send for WindowAsWindowHandle<'a> {}
+unsafe impl<'a> Sync for WindowAsWindowHandle<'a> {}
+
+impl<'a> HasWindowHandle for WindowAsWindowHandle<'a> {
+	fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
+		Ok(self.window_handle)
+	}
+}
+
+impl<'a> HasDisplayHandle for WindowAsWindowHandle<'a> {
+	fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
+		Ok(self.display_handle)
+	}
+}
+
+impl Window {
+	pub fn as_window_handle<'a>(&'a self) -> Result<WindowAsWindowHandle<'a>, HandleError> {
+		Ok(WindowAsWindowHandle {
+			window_handle: window_handle(self)?,
+			display_handle: display_handle(self)?,
+		})
+	}
+}
+
 // Access window handle using SDL3 properties
-impl HasWindowHandle for Window {
-    fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
-        // Windows
-        #[cfg(target_os = "windows")]
-        unsafe {
-            use self::raw_window_handle::Win32WindowHandle;
+fn window_handle<'a>(window: &'a Window) -> Result<WindowHandle<'a>, HandleError> {
+	// Windows
+	#[cfg(target_os = "windows")]
+	unsafe {
+		use self::raw_window_handle::Win32WindowHandle;
 
-            let window_properties = sys::video::SDL_GetWindowProperties(self.raw());
+		let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
 
-            let hwnd = SDL_GetPointerProperty(
-                window_properties,
-                sys::video::SDL_PROP_WINDOW_WIN32_HWND_POINTER,
-                std::ptr::null_mut(),
-            );
-            let hinstance = SDL_GetPointerProperty(
-                window_properties,
-                sys::video::SDL_PROP_WINDOW_WIN32_INSTANCE_POINTER,
-                std::ptr::null_mut(),
-            );
-            let mut handle = Win32WindowHandle::new(NonZero::new_unchecked(hwnd.addr() as isize));
-            handle.hinstance = Some(NonZero::new_unchecked(hinstance.addr() as isize));
-            let raw_window_handle = RawWindowHandle::Win32(handle);
+		let hwnd = SDL_GetPointerProperty(
+			window_properties,
+			sys::video::SDL_PROP_WINDOW_WIN32_HWND_POINTER,
+			std::ptr::null_mut(),
+		);
+		let hinstance = SDL_GetPointerProperty(
+			window_properties,
+			sys::video::SDL_PROP_WINDOW_WIN32_INSTANCE_POINTER,
+			std::ptr::null_mut(),
+		);
+		let mut handle = Win32WindowHandle::new(NonZero::new_unchecked(hwnd.addr() as isize));
+		handle.hinstance = Some(NonZero::new_unchecked(hinstance.addr() as isize));
+		let raw_window_handle = RawWindowHandle::Win32(handle);
 
-            Ok(WindowHandle::borrow_raw(raw_window_handle))
-        }
+		Ok(WindowHandle::borrow_raw(raw_window_handle))
+	}
 
-        // macOS
-        #[cfg(target_os = "macos")]
-        unsafe {
-            use self::raw_window_handle::AppKitWindowHandle;
-            use objc2::{msg_send, runtime::NSObject};
+	// macOS
+	#[cfg(target_os = "macos")]
+	unsafe {
+		use self::raw_window_handle::AppKitWindowHandle;
+		use objc2::{msg_send, runtime::NSObject};
 
-            let window_properties = sys::video::SDL_GetWindowProperties(self.raw());
+		let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
 
-            let ns_window = SDL_GetPointerProperty(
-                window_properties,
-                sys::video::SDL_PROP_WINDOW_COCOA_WINDOW_POINTER,
-                std::ptr::null_mut(),
-            );
-            let ns_view: *mut NSObject = msg_send![ns_window as *mut NSObject, contentView];
-            if ns_view.is_null() {
-                return Err(HandleError::Unavailable);
-            }
-            let handle = AppKitWindowHandle::new(NonNull::new_unchecked(ns_view.cast()));
-            let raw_window_handle = RawWindowHandle::AppKit(handle);
+		let ns_window = SDL_GetPointerProperty(
+			window_properties,
+			sys::video::SDL_PROP_WINDOW_COCOA_WINDOW_POINTER,
+			std::ptr::null_mut(),
+		);
+		let ns_view: *mut NSObject = msg_send![ns_window as *mut NSObject, contentView];
+		if ns_view.is_null() {
+			return Err(HandleError::Unavailable);
+		}
+		let handle = AppKitWindowHandle::new(NonNull::new_unchecked(ns_view.cast()));
+		let raw_window_handle = RawWindowHandle::AppKit(handle);
 
-            Ok(WindowHandle::borrow_raw(raw_window_handle))
-        }
+		Ok(WindowHandle::borrow_raw(raw_window_handle))
+	}
 
-        // iOS
-        #[cfg(target_os = "ios")]
-        unsafe {
-            use self::raw_window_handle::UiKitWindowHandle;
+	// iOS
+	#[cfg(target_os = "ios")]
+	unsafe {
+		use self::raw_window_handle::UiKitWindowHandle;
 
-            let window_properties = sys::video::SDL_GetWindowProperties(self.raw());
+		let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
 
-            let ui_view = SDL_GetPointerProperty(
-                window_properties,
-                sys::video::SDL_PROP_WINDOW_UIKIT_WINDOW_POINTER,
-                std::ptr::null_mut(),
-            );
-            let handle = UiKitWindowHandle::new(NonNull::new_unchecked(ui_view));
-            let raw_window_handle = RawWindowHandle::UiKit(handle);
+		let ui_view = SDL_GetPointerProperty(
+			window_properties,
+			sys::video::SDL_PROP_WINDOW_UIKIT_WINDOW_POINTER,
+			std::ptr::null_mut(),
+		);
+		let handle = UiKitWindowHandle::new(NonNull::new_unchecked(ui_view));
+		let raw_window_handle = RawWindowHandle::UiKit(handle);
 
-            Ok(WindowHandle::borrow_raw(raw_window_handle))
-        }
+		Ok(WindowHandle::borrow_raw(raw_window_handle))
+	}
 
-        // Android
-        #[cfg(target_os = "android")]
-        unsafe {
-            use self::raw_window_handle::AndroidNdkWindowHandle;
+	// Android
+	#[cfg(target_os = "android")]
+	unsafe {
+		use self::raw_window_handle::AndroidNdkWindowHandle;
 
-            let window_properties = sys::video::SDL_GetWindowProperties(self.raw());
+		let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
 
-            let native_window = SDL_GetPointerProperty(
-                window_properties,
-                sys::video::SDL_PROP_WINDOW_ANDROID_WINDOW_POINTER,
-                std::ptr::null_mut(),
-            );
-            let handle = AndroidNdkWindowHandle::new(NonNull::new_unchecked(native_window));
-            let raw_window_handle = RawWindowHandle::AndroidNdk(handle);
+		let native_window = SDL_GetPointerProperty(
+			window_properties,
+			sys::video::SDL_PROP_WINDOW_ANDROID_WINDOW_POINTER,
+			std::ptr::null_mut(),
+		);
+		let handle = AndroidNdkWindowHandle::new(NonNull::new_unchecked(native_window));
+		let raw_window_handle = RawWindowHandle::AndroidNdk(handle);
 
-            Ok(WindowHandle::borrow_raw(raw_window_handle))
-        }
+		Ok(WindowHandle::borrow_raw(raw_window_handle))
+	}
 
-        // Linux (X11 or Wayland)
-        #[cfg(all(
-            unix,
-            not(target_os = "macos"),
-            not(target_os = "ios"),
-            not(target_os = "android")
-        ))]
-        unsafe {
-            let video_driver = CStr::from_ptr(sys::video::SDL_GetCurrentVideoDriver());
+	// Linux (X11 or Wayland)
+	#[cfg(all(
+		unix,
+		not(target_os = "macos"),
+		not(target_os = "ios"),
+		not(target_os = "android")
+	))]
+	unsafe {
+		let video_driver = CStr::from_ptr(sys::video::SDL_GetCurrentVideoDriver());
 
-            match video_driver.to_bytes() {
-                b"x11" => {
-                    use self::raw_window_handle::XlibWindowHandle;
+		match video_driver.to_bytes() {
+			b"x11" => {
+				use self::raw_window_handle::XlibWindowHandle;
 
-                    let window_properties = sys::video::SDL_GetWindowProperties(self.raw());
+				let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
 
-                    let window = SDL_GetNumberProperty(
-                        window_properties,
-                        sys::video::SDL_PROP_WINDOW_X11_WINDOW_NUMBER,
-                        0,
-                    );
-                    let handle = XlibWindowHandle::new(window as u64);
-                    let raw_window_handle = RawWindowHandle::Xlib(handle);
+				let window = SDL_GetNumberProperty(
+					window_properties,
+					sys::video::SDL_PROP_WINDOW_X11_WINDOW_NUMBER,
+					0,
+				);
+				let handle = XlibWindowHandle::new(window as u64);
+				let raw_window_handle = RawWindowHandle::Xlib(handle);
 
-                    Ok(WindowHandle::borrow_raw(raw_window_handle))
-                }
-                b"wayland" => {
-                    use self::raw_window_handle::WaylandWindowHandle;
+				Ok(WindowHandle::borrow_raw(raw_window_handle))
+			}
+			b"wayland" => {
+				use self::raw_window_handle::WaylandWindowHandle;
 
-                    let window_properties = sys::video::SDL_GetWindowProperties(self.raw());
+				let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
 
-                    let window = SDL_GetPointerProperty(
-                        window_properties,
-                        sys::video::SDL_PROP_WINDOW_WAYLAND_SURFACE_POINTER,
-                        std::ptr::null_mut(),
-                    );
-                    let handle = WaylandWindowHandle::new(NonNull::new_unchecked(window));
-                    let raw_window_handle = RawWindowHandle::Wayland(handle);
+				let window = SDL_GetPointerProperty(
+					window_properties,
+					sys::video::SDL_PROP_WINDOW_WAYLAND_SURFACE_POINTER,
+					std::ptr::null_mut(),
+				);
+				let handle = WaylandWindowHandle::new(NonNull::new_unchecked(window));
+				let raw_window_handle = RawWindowHandle::Wayland(handle);
 
-                    Ok(WindowHandle::borrow_raw(raw_window_handle))
-                }
-                _ => {
-                    panic!("{video_driver:?} video driver is not supported, please file an issue with raw-window-handle.",);
-                }
-            }
-        }
-    }
+				Ok(WindowHandle::borrow_raw(raw_window_handle))
+			}
+			_ => {
+				panic!("{video_driver:?} video driver is not supported, please file an issue with raw-window-handle.",);
+			}
+		}
+	}
 }
 
 // Access display handle using SDL3 properties
-impl HasDisplayHandle for Window {
-    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
-        // Windows
-        #[cfg(target_os = "windows")]
-        unsafe {
-            use self::raw_window_handle::WindowsDisplayHandle;
-            let handle = WindowsDisplayHandle::new();
-            let raw_window_handle = RawDisplayHandle::Windows(handle);
+fn display_handle<'a>(window: &'a Window) -> Result<DisplayHandle<'a>, HandleError> {
+	// Windows
+	#[cfg(target_os = "windows")]
+	unsafe {
+		use self::raw_window_handle::WindowsDisplayHandle;
+		let handle = WindowsDisplayHandle::new();
+		let raw_window_handle = RawDisplayHandle::Windows(handle);
 
-            Ok(DisplayHandle::borrow_raw(raw_window_handle))
-        }
+		Ok(DisplayHandle::borrow_raw(raw_window_handle))
+	}
 
-        // macOS
-        #[cfg(target_os = "macos")]
-        unsafe {
-            use self::raw_window_handle::AppKitDisplayHandle;
-            let handle = AppKitDisplayHandle::new();
-            let raw_window_handle = RawDisplayHandle::AppKit(handle);
+	// macOS
+	#[cfg(target_os = "macos")]
+	unsafe {
+		use self::raw_window_handle::AppKitDisplayHandle;
+		let handle = AppKitDisplayHandle::new();
+		let raw_window_handle = RawDisplayHandle::AppKit(handle);
 
-            Ok(DisplayHandle::borrow_raw(raw_window_handle))
-        }
+		Ok(DisplayHandle::borrow_raw(raw_window_handle))
+	}
 
-        // iOS
-        #[cfg(target_os = "ios")]
-        unsafe {
-            use self::raw_window_handle::UiKitDisplayHandle;
-            let handle = UiKitDisplayHandle::new();
-            let raw_window_handle = RawDisplayHandle::UiKit(handle);
+	// iOS
+	#[cfg(target_os = "ios")]
+	unsafe {
+		use self::raw_window_handle::UiKitDisplayHandle;
+		let handle = UiKitDisplayHandle::new();
+		let raw_window_handle = RawDisplayHandle::UiKit(handle);
 
-            Ok(DisplayHandle::borrow_raw(raw_window_handle))
-        }
+		Ok(DisplayHandle::borrow_raw(raw_window_handle))
+	}
 
-        // Android
-        #[cfg(target_os = "android")]
-        unsafe {
-            use self::raw_window_handle::AndroidDisplayHandle;
-            let handle = AndroidDisplayHandle::new();
-            let raw_window_handle = RawDisplayHandle::Android(handle);
+	// Android
+	#[cfg(target_os = "android")]
+	unsafe {
+		use self::raw_window_handle::AndroidDisplayHandle;
+		let handle = AndroidDisplayHandle::new();
+		let raw_window_handle = RawDisplayHandle::Android(handle);
 
-            Ok(DisplayHandle::borrow_raw(raw_window_handle))
-        }
+		Ok(DisplayHandle::borrow_raw(raw_window_handle))
+	}
 
-        // Linux (X11 or Wayland)
-        #[cfg(all(
-            unix,
-            not(target_os = "macos"),
-            not(target_os = "ios"),
-            not(target_os = "android")
-        ))]
-        unsafe {
-            let video_driver = CStr::from_ptr(sys::video::SDL_GetCurrentVideoDriver());
+	// Linux (X11 or Wayland)
+	#[cfg(all(
+		unix,
+		not(target_os = "macos"),
+		not(target_os = "ios"),
+		not(target_os = "android")
+	))]
+	unsafe {
+		let video_driver = CStr::from_ptr(sys::video::SDL_GetCurrentVideoDriver());
 
-            match video_driver.to_bytes() {
-                b"x11" => {
-                    use self::raw_window_handle::XlibDisplayHandle;
+		match video_driver.to_bytes() {
+			b"x11" => {
+				use self::raw_window_handle::XlibDisplayHandle;
 
-                    let window_properties = sys::video::SDL_GetWindowProperties(self.raw());
+				let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
 
-                    let display = SDL_GetPointerProperty(
-                        window_properties,
-                        sys::video::SDL_PROP_WINDOW_X11_DISPLAY_POINTER,
-                        std::ptr::null_mut(),
-                    );
-                    let display = core::ptr::NonNull::<libc::c_void>::new(display);
+				let display = SDL_GetPointerProperty(
+					window_properties,
+					sys::video::SDL_PROP_WINDOW_X11_DISPLAY_POINTER,
+					std::ptr::null_mut(),
+				);
+				let display = core::ptr::NonNull::<libc::c_void>::new(display);
 
-                    let window = SDL_GetNumberProperty(
-                        window_properties,
-                        sys::video::SDL_PROP_WINDOW_X11_SCREEN_NUMBER,
-                        0,
-                    );
-                    let handle = XlibDisplayHandle::new(display, window as i32);
-                    let raw_window_handle = RawDisplayHandle::Xlib(handle);
+				let window = SDL_GetNumberProperty(
+					window_properties,
+					sys::video::SDL_PROP_WINDOW_X11_SCREEN_NUMBER,
+					0,
+				);
+				let handle = XlibDisplayHandle::new(display, window as i32);
+				let raw_window_handle = RawDisplayHandle::Xlib(handle);
 
-                    Ok(DisplayHandle::borrow_raw(raw_window_handle))
-                }
-                b"wayland" => {
-                    use self::raw_window_handle::WaylandDisplayHandle;
+				Ok(DisplayHandle::borrow_raw(raw_window_handle))
+			}
+			b"wayland" => {
+				use self::raw_window_handle::WaylandDisplayHandle;
 
-                    let window_properties = sys::video::SDL_GetWindowProperties(self.raw());
+				let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
 
-                    let display = SDL_GetPointerProperty(
-                        window_properties,
-                        sys::video::SDL_PROP_WINDOW_WAYLAND_DISPLAY_POINTER,
-                        std::ptr::null_mut(),
-                    );
-                    let Some(display) = core::ptr::NonNull::<libc::c_void>::new(display) else {
-                        return Err(HandleError::Unavailable); // I'm unsure if this is the right error type, of if we should just panic here if the display isn't available?
-                    };
-                    let handle = WaylandDisplayHandle::new(display);
-                    let raw_window_handle = RawDisplayHandle::Wayland(handle);
+				let display = SDL_GetPointerProperty(
+					window_properties,
+					sys::video::SDL_PROP_WINDOW_WAYLAND_DISPLAY_POINTER,
+					std::ptr::null_mut(),
+				);
+				let Some(display) = core::ptr::NonNull::<libc::c_void>::new(display) else {
+					return Err(HandleError::Unavailable); // I'm unsure if this is the right error type, of if we should just panic here if the display isn't available?
+				};
+				let handle = WaylandDisplayHandle::new(display);
+				let raw_window_handle = RawDisplayHandle::Wayland(handle);
 
-                    Ok(DisplayHandle::borrow_raw(raw_window_handle))
-                }
-                _ => {
-                    panic!("{video_driver:?} video driver is not supported, please file an issue with raw-window-handle.");
-                }
-            }
-        }
-    }
+				Ok(DisplayHandle::borrow_raw(raw_window_handle))
+			}
+			_ => {
+				panic!("{video_driver:?} video driver is not supported, please file an issue with raw-window-handle.");
+			}
+		}
+	}
 }

--- a/src/sdl3/raw_window_handle.rs
+++ b/src/sdl3/raw_window_handle.rs
@@ -6,7 +6,10 @@ use raw_window_handle::{
     RawWindowHandle, WindowHandle,
 };
 use std::{ffi::CStr, num::NonZero, ptr::NonNull};
-use sys::{properties::{SDL_GetNumberProperty, SDL_GetPointerProperty}, video::SDL_Window};
+use sys::{
+    properties::{SDL_GetNumberProperty, SDL_GetPointerProperty},
+    video::SDL_Window,
+};
 
 // this queries then stores all handles upon creation, then returns the stored values on request
 
@@ -39,9 +42,11 @@ impl Window {
             display_handle: display_handle(self.raw())?,
         })
     }
-	// Safety: this does break rust's safety rule that you cannot modify something while there are other references to it, but following that rule religiously here would do more harm than good
+    // Safety: this does break rust's safety rule that you cannot modify something while there are other references to it, but following that rule religiously here would do more harm than good
     /// Gives a window handle that can be used by crates like wgpu, glutin, etc. Unlike `Window::as_window_handle()`, this gives back a mutable reference which can be used for methods which take `&mut Self` (such as `window.show()`, `window.minimize()`, etc)
-    pub fn mut_as_window_handle<'a>(&'a mut self) -> Result<(&'a mut Self, WindowAsWindowHandle<'a>), HandleError> {
+    pub fn mut_as_window_handle<'a>(
+        &'a mut self,
+    ) -> Result<(&'a mut Self, WindowAsWindowHandle<'a>), HandleError> {
         let handle = WindowAsWindowHandle {
             window_handle: window_handle(self.raw())?,
             display_handle: display_handle(self.raw())?,
@@ -79,8 +84,8 @@ fn window_handle<'a>(raw_window: *mut SDL_Window) -> Result<WindowHandle<'a>, Ha
     // macOS
     #[cfg(target_os = "macos")]
     unsafe {
-        use raw_window_handle::AppKitWindowHandle;
         use objc2::{msg_send, runtime::NSObject};
+        use raw_window_handle::AppKitWindowHandle;
 
         let window_properties = sys::video::SDL_GetWindowProperties(raw_window);
 

--- a/src/sdl3/raw_window_handle.rs
+++ b/src/sdl3/raw_window_handle.rs
@@ -14,40 +14,41 @@ use sys::{
 // this queries then stores all handles upon creation, then returns the stored values on request
 
 #[derive(Debug, PartialEq)]
-pub struct WindowAsWindowHandle<'a> {
+pub struct WindowHandles<'a> {
     window_handle: WindowHandle<'a>,
     display_handle: DisplayHandle<'a>,
 }
 
-unsafe impl<'a> Send for WindowAsWindowHandle<'a> {}
-unsafe impl<'a> Sync for WindowAsWindowHandle<'a> {}
+// Note: this is necessary because Wgpu needs the given window handle struct to be Send/Sync
+// Safety: WindowHandles' only job is to store and give out WindowHandle and DisplayHandle values. These handles are simple raw data structs, which means moving and/or referencing WindowHandles across threads is safe. The only methods for WindowHandles simply return the stored raw data, which means using this across threads is safe
+unsafe impl<'a> Send for WindowHandles<'a> {}
+unsafe impl<'a> Sync for WindowHandles<'a> {}
 
-impl<'a> HasWindowHandle for WindowAsWindowHandle<'a> {
-    fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
+impl<'a> HasWindowHandle for WindowHandles<'a> {
+    fn window_handle(&self) -> Result<WindowHandle<'a>, HandleError> {
         Ok(self.window_handle)
     }
 }
 
-impl<'a> HasDisplayHandle for WindowAsWindowHandle<'a> {
-    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
+impl<'a> HasDisplayHandle for WindowHandles<'a> {
+    fn display_handle(&self) -> Result<DisplayHandle<'a>, HandleError> {
         Ok(self.display_handle)
     }
 }
 
 impl Window {
-    /// Gives a window handle that can be used by crates like wgpu, glutin, etc. Note: using this function means you cannot use methods on `sdl3::video::Window` which take `&mut Self` (such as `window.show()`, `window.minimize()`, etc), if you need to these functions then use `Window::mut_as_window_handle()` instead.
-    pub fn as_window_handle<'a>(&'a self) -> Result<WindowAsWindowHandle<'a>, HandleError> {
-        Ok(WindowAsWindowHandle {
+    /// Gives a window handles struct that can be used by crates like wgpu, glutin, etc. Note: using this function means you cannot use methods on `sdl3::video::Window` which take `&mut Self` (such as `window.show()`, `window.minimize()`, etc), if you need to these functions then use `Window::as_window_handles_mut()` instead.
+    pub fn as_window_handles<'a>(&'a self) -> Result<WindowHandles<'a>, HandleError> {
+        Ok(WindowHandles {
             window_handle: window_handle(self.raw())?,
             display_handle: display_handle(self.raw())?,
         })
     }
-    // Safety: this does break rust's safety rule that you cannot modify something while there are other references to it, but following that rule religiously here would do more harm than good
-    /// Gives a window handle that can be used by crates like wgpu, glutin, etc. Unlike `Window::as_window_handle()`, this gives back a mutable reference which can be used for methods which take `&mut Self` (such as `window.show()`, `window.minimize()`, etc)
-    pub fn mut_as_window_handle<'a>(
+    /// Gives a window handles struct that can be used by crates like wgpu, glutin, etc. Unlike `Window::as_window_handles()`, this gives back a mutable reference which can be used for methods which take `&mut Self` (such as `window.show()`, `window.minimize()`, etc)
+    pub fn as_window_handles_mut<'a>(
         &'a mut self,
-    ) -> Result<(&'a mut Self, WindowAsWindowHandle<'a>), HandleError> {
-        let handle = WindowAsWindowHandle {
+    ) -> Result<(&'a mut Self, WindowHandles<'a>), HandleError> {
+        let handle = WindowHandles {
             window_handle: window_handle(self.raw())?,
             display_handle: display_handle(self.raw())?,
         };

--- a/src/sdl3/raw_window_handle.rs
+++ b/src/sdl3/raw_window_handle.rs
@@ -8,263 +8,263 @@ use sys::properties::{SDL_GetNumberProperty, SDL_GetPointerProperty};
 // this queries then stores all handles upon creation, then returns the stored values on request
 
 pub struct WindowAsWindowHandle<'a> {
-	window_handle: WindowHandle<'a>,
-	display_handle: DisplayHandle<'a>,
+    window_handle: WindowHandle<'a>,
+    display_handle: DisplayHandle<'a>,
 }
 
 unsafe impl<'a> Send for WindowAsWindowHandle<'a> {}
 unsafe impl<'a> Sync for WindowAsWindowHandle<'a> {}
 
 impl<'a> HasWindowHandle for WindowAsWindowHandle<'a> {
-	fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
-		Ok(self.window_handle)
-	}
+    fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
+        Ok(self.window_handle)
+    }
 }
 
 impl<'a> HasDisplayHandle for WindowAsWindowHandle<'a> {
-	fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
-		Ok(self.display_handle)
-	}
+    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
+        Ok(self.display_handle)
+    }
 }
 
 impl Window {
-	pub fn as_window_handle<'a>(&'a self) -> Result<WindowAsWindowHandle<'a>, HandleError> {
-		Ok(WindowAsWindowHandle {
-			window_handle: window_handle(self)?,
-			display_handle: display_handle(self)?,
-		})
-	}
+    pub fn as_window_handle<'a>(&'a self) -> Result<WindowAsWindowHandle<'a>, HandleError> {
+        Ok(WindowAsWindowHandle {
+            window_handle: window_handle(self)?,
+            display_handle: display_handle(self)?,
+        })
+    }
 }
 
 // Access window handle using SDL3 properties
 fn window_handle<'a>(window: &'a Window) -> Result<WindowHandle<'a>, HandleError> {
-	// Windows
-	#[cfg(target_os = "windows")]
-	unsafe {
-		use self::raw_window_handle::Win32WindowHandle;
+    // Windows
+    #[cfg(target_os = "windows")]
+    unsafe {
+        use self::raw_window_handle::Win32WindowHandle;
 
-		let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
+        let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
 
-		let hwnd = SDL_GetPointerProperty(
-			window_properties,
-			sys::video::SDL_PROP_WINDOW_WIN32_HWND_POINTER,
-			std::ptr::null_mut(),
-		);
-		let hinstance = SDL_GetPointerProperty(
-			window_properties,
-			sys::video::SDL_PROP_WINDOW_WIN32_INSTANCE_POINTER,
-			std::ptr::null_mut(),
-		);
-		let mut handle = Win32WindowHandle::new(NonZero::new_unchecked(hwnd.addr() as isize));
-		handle.hinstance = Some(NonZero::new_unchecked(hinstance.addr() as isize));
-		let raw_window_handle = RawWindowHandle::Win32(handle);
+        let hwnd = SDL_GetPointerProperty(
+            window_properties,
+            sys::video::SDL_PROP_WINDOW_WIN32_HWND_POINTER,
+            std::ptr::null_mut(),
+        );
+        let hinstance = SDL_GetPointerProperty(
+            window_properties,
+            sys::video::SDL_PROP_WINDOW_WIN32_INSTANCE_POINTER,
+            std::ptr::null_mut(),
+        );
+        let mut handle = Win32WindowHandle::new(NonZero::new_unchecked(hwnd.addr() as isize));
+        handle.hinstance = Some(NonZero::new_unchecked(hinstance.addr() as isize));
+        let raw_window_handle = RawWindowHandle::Win32(handle);
 
-		Ok(WindowHandle::borrow_raw(raw_window_handle))
-	}
+        Ok(WindowHandle::borrow_raw(raw_window_handle))
+    }
 
-	// macOS
-	#[cfg(target_os = "macos")]
-	unsafe {
-		use self::raw_window_handle::AppKitWindowHandle;
-		use objc2::{msg_send, runtime::NSObject};
+    // macOS
+    #[cfg(target_os = "macos")]
+    unsafe {
+        use self::raw_window_handle::AppKitWindowHandle;
+        use objc2::{msg_send, runtime::NSObject};
 
-		let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
+        let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
 
-		let ns_window = SDL_GetPointerProperty(
-			window_properties,
-			sys::video::SDL_PROP_WINDOW_COCOA_WINDOW_POINTER,
-			std::ptr::null_mut(),
-		);
-		let ns_view: *mut NSObject = msg_send![ns_window as *mut NSObject, contentView];
-		if ns_view.is_null() {
-			return Err(HandleError::Unavailable);
-		}
-		let handle = AppKitWindowHandle::new(NonNull::new_unchecked(ns_view.cast()));
-		let raw_window_handle = RawWindowHandle::AppKit(handle);
+        let ns_window = SDL_GetPointerProperty(
+            window_properties,
+            sys::video::SDL_PROP_WINDOW_COCOA_WINDOW_POINTER,
+            std::ptr::null_mut(),
+        );
+        let ns_view: *mut NSObject = msg_send![ns_window as *mut NSObject, contentView];
+        if ns_view.is_null() {
+            return Err(HandleError::Unavailable);
+        }
+        let handle = AppKitWindowHandle::new(NonNull::new_unchecked(ns_view.cast()));
+        let raw_window_handle = RawWindowHandle::AppKit(handle);
 
-		Ok(WindowHandle::borrow_raw(raw_window_handle))
-	}
+        Ok(WindowHandle::borrow_raw(raw_window_handle))
+    }
 
-	// iOS
-	#[cfg(target_os = "ios")]
-	unsafe {
-		use self::raw_window_handle::UiKitWindowHandle;
+    // iOS
+    #[cfg(target_os = "ios")]
+    unsafe {
+        use self::raw_window_handle::UiKitWindowHandle;
 
-		let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
+        let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
 
-		let ui_view = SDL_GetPointerProperty(
-			window_properties,
-			sys::video::SDL_PROP_WINDOW_UIKIT_WINDOW_POINTER,
-			std::ptr::null_mut(),
-		);
-		let handle = UiKitWindowHandle::new(NonNull::new_unchecked(ui_view));
-		let raw_window_handle = RawWindowHandle::UiKit(handle);
+        let ui_view = SDL_GetPointerProperty(
+            window_properties,
+            sys::video::SDL_PROP_WINDOW_UIKIT_WINDOW_POINTER,
+            std::ptr::null_mut(),
+        );
+        let handle = UiKitWindowHandle::new(NonNull::new_unchecked(ui_view));
+        let raw_window_handle = RawWindowHandle::UiKit(handle);
 
-		Ok(WindowHandle::borrow_raw(raw_window_handle))
-	}
+        Ok(WindowHandle::borrow_raw(raw_window_handle))
+    }
 
-	// Android
-	#[cfg(target_os = "android")]
-	unsafe {
-		use self::raw_window_handle::AndroidNdkWindowHandle;
+    // Android
+    #[cfg(target_os = "android")]
+    unsafe {
+        use self::raw_window_handle::AndroidNdkWindowHandle;
 
-		let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
+        let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
 
-		let native_window = SDL_GetPointerProperty(
-			window_properties,
-			sys::video::SDL_PROP_WINDOW_ANDROID_WINDOW_POINTER,
-			std::ptr::null_mut(),
-		);
-		let handle = AndroidNdkWindowHandle::new(NonNull::new_unchecked(native_window));
-		let raw_window_handle = RawWindowHandle::AndroidNdk(handle);
+        let native_window = SDL_GetPointerProperty(
+            window_properties,
+            sys::video::SDL_PROP_WINDOW_ANDROID_WINDOW_POINTER,
+            std::ptr::null_mut(),
+        );
+        let handle = AndroidNdkWindowHandle::new(NonNull::new_unchecked(native_window));
+        let raw_window_handle = RawWindowHandle::AndroidNdk(handle);
 
-		Ok(WindowHandle::borrow_raw(raw_window_handle))
-	}
+        Ok(WindowHandle::borrow_raw(raw_window_handle))
+    }
 
-	// Linux (X11 or Wayland)
-	#[cfg(all(
-		unix,
-		not(target_os = "macos"),
-		not(target_os = "ios"),
-		not(target_os = "android")
-	))]
-	unsafe {
-		let video_driver = CStr::from_ptr(sys::video::SDL_GetCurrentVideoDriver());
+    // Linux (X11 or Wayland)
+    #[cfg(all(
+        unix,
+        not(target_os = "macos"),
+        not(target_os = "ios"),
+        not(target_os = "android")
+    ))]
+    unsafe {
+        let video_driver = CStr::from_ptr(sys::video::SDL_GetCurrentVideoDriver());
 
-		match video_driver.to_bytes() {
-			b"x11" => {
-				use self::raw_window_handle::XlibWindowHandle;
+        match video_driver.to_bytes() {
+            b"x11" => {
+                use self::raw_window_handle::XlibWindowHandle;
 
-				let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
+                let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
 
-				let window = SDL_GetNumberProperty(
-					window_properties,
-					sys::video::SDL_PROP_WINDOW_X11_WINDOW_NUMBER,
-					0,
-				);
-				let handle = XlibWindowHandle::new(window as u64);
-				let raw_window_handle = RawWindowHandle::Xlib(handle);
+                let window = SDL_GetNumberProperty(
+                    window_properties,
+                    sys::video::SDL_PROP_WINDOW_X11_WINDOW_NUMBER,
+                    0,
+                );
+                let handle = XlibWindowHandle::new(window as u64);
+                let raw_window_handle = RawWindowHandle::Xlib(handle);
 
-				Ok(WindowHandle::borrow_raw(raw_window_handle))
-			}
-			b"wayland" => {
-				use self::raw_window_handle::WaylandWindowHandle;
+                Ok(WindowHandle::borrow_raw(raw_window_handle))
+            }
+            b"wayland" => {
+                use self::raw_window_handle::WaylandWindowHandle;
 
-				let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
+                let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
 
-				let window = SDL_GetPointerProperty(
-					window_properties,
-					sys::video::SDL_PROP_WINDOW_WAYLAND_SURFACE_POINTER,
-					std::ptr::null_mut(),
-				);
-				let handle = WaylandWindowHandle::new(NonNull::new_unchecked(window));
-				let raw_window_handle = RawWindowHandle::Wayland(handle);
+                let window = SDL_GetPointerProperty(
+                    window_properties,
+                    sys::video::SDL_PROP_WINDOW_WAYLAND_SURFACE_POINTER,
+                    std::ptr::null_mut(),
+                );
+                let handle = WaylandWindowHandle::new(NonNull::new_unchecked(window));
+                let raw_window_handle = RawWindowHandle::Wayland(handle);
 
-				Ok(WindowHandle::borrow_raw(raw_window_handle))
-			}
-			_ => {
-				panic!("{video_driver:?} video driver is not supported, please file an issue with raw-window-handle.",);
-			}
-		}
-	}
+                Ok(WindowHandle::borrow_raw(raw_window_handle))
+            }
+            _ => {
+                panic!("{video_driver:?} video driver is not supported, please file an issue with raw-window-handle.",);
+            }
+        }
+    }
 }
 
 // Access display handle using SDL3 properties
 fn display_handle<'a>(window: &'a Window) -> Result<DisplayHandle<'a>, HandleError> {
-	// Windows
-	#[cfg(target_os = "windows")]
-	unsafe {
-		use self::raw_window_handle::WindowsDisplayHandle;
-		let handle = WindowsDisplayHandle::new();
-		let raw_window_handle = RawDisplayHandle::Windows(handle);
+    // Windows
+    #[cfg(target_os = "windows")]
+    unsafe {
+        use self::raw_window_handle::WindowsDisplayHandle;
+        let handle = WindowsDisplayHandle::new();
+        let raw_window_handle = RawDisplayHandle::Windows(handle);
 
-		Ok(DisplayHandle::borrow_raw(raw_window_handle))
-	}
+        Ok(DisplayHandle::borrow_raw(raw_window_handle))
+    }
 
-	// macOS
-	#[cfg(target_os = "macos")]
-	unsafe {
-		use self::raw_window_handle::AppKitDisplayHandle;
-		let handle = AppKitDisplayHandle::new();
-		let raw_window_handle = RawDisplayHandle::AppKit(handle);
+    // macOS
+    #[cfg(target_os = "macos")]
+    unsafe {
+        use self::raw_window_handle::AppKitDisplayHandle;
+        let handle = AppKitDisplayHandle::new();
+        let raw_window_handle = RawDisplayHandle::AppKit(handle);
 
-		Ok(DisplayHandle::borrow_raw(raw_window_handle))
-	}
+        Ok(DisplayHandle::borrow_raw(raw_window_handle))
+    }
 
-	// iOS
-	#[cfg(target_os = "ios")]
-	unsafe {
-		use self::raw_window_handle::UiKitDisplayHandle;
-		let handle = UiKitDisplayHandle::new();
-		let raw_window_handle = RawDisplayHandle::UiKit(handle);
+    // iOS
+    #[cfg(target_os = "ios")]
+    unsafe {
+        use self::raw_window_handle::UiKitDisplayHandle;
+        let handle = UiKitDisplayHandle::new();
+        let raw_window_handle = RawDisplayHandle::UiKit(handle);
 
-		Ok(DisplayHandle::borrow_raw(raw_window_handle))
-	}
+        Ok(DisplayHandle::borrow_raw(raw_window_handle))
+    }
 
-	// Android
-	#[cfg(target_os = "android")]
-	unsafe {
-		use self::raw_window_handle::AndroidDisplayHandle;
-		let handle = AndroidDisplayHandle::new();
-		let raw_window_handle = RawDisplayHandle::Android(handle);
+    // Android
+    #[cfg(target_os = "android")]
+    unsafe {
+        use self::raw_window_handle::AndroidDisplayHandle;
+        let handle = AndroidDisplayHandle::new();
+        let raw_window_handle = RawDisplayHandle::Android(handle);
 
-		Ok(DisplayHandle::borrow_raw(raw_window_handle))
-	}
+        Ok(DisplayHandle::borrow_raw(raw_window_handle))
+    }
 
-	// Linux (X11 or Wayland)
-	#[cfg(all(
-		unix,
-		not(target_os = "macos"),
-		not(target_os = "ios"),
-		not(target_os = "android")
-	))]
-	unsafe {
-		let video_driver = CStr::from_ptr(sys::video::SDL_GetCurrentVideoDriver());
+    // Linux (X11 or Wayland)
+    #[cfg(all(
+        unix,
+        not(target_os = "macos"),
+        not(target_os = "ios"),
+        not(target_os = "android")
+    ))]
+    unsafe {
+        let video_driver = CStr::from_ptr(sys::video::SDL_GetCurrentVideoDriver());
 
-		match video_driver.to_bytes() {
-			b"x11" => {
-				use self::raw_window_handle::XlibDisplayHandle;
+        match video_driver.to_bytes() {
+            b"x11" => {
+                use self::raw_window_handle::XlibDisplayHandle;
 
-				let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
+                let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
 
-				let display = SDL_GetPointerProperty(
-					window_properties,
-					sys::video::SDL_PROP_WINDOW_X11_DISPLAY_POINTER,
-					std::ptr::null_mut(),
-				);
-				let display = core::ptr::NonNull::<libc::c_void>::new(display);
+                let display = SDL_GetPointerProperty(
+                    window_properties,
+                    sys::video::SDL_PROP_WINDOW_X11_DISPLAY_POINTER,
+                    std::ptr::null_mut(),
+                );
+                let display = core::ptr::NonNull::<libc::c_void>::new(display);
 
-				let window = SDL_GetNumberProperty(
-					window_properties,
-					sys::video::SDL_PROP_WINDOW_X11_SCREEN_NUMBER,
-					0,
-				);
-				let handle = XlibDisplayHandle::new(display, window as i32);
-				let raw_window_handle = RawDisplayHandle::Xlib(handle);
+                let window = SDL_GetNumberProperty(
+                    window_properties,
+                    sys::video::SDL_PROP_WINDOW_X11_SCREEN_NUMBER,
+                    0,
+                );
+                let handle = XlibDisplayHandle::new(display, window as i32);
+                let raw_window_handle = RawDisplayHandle::Xlib(handle);
 
-				Ok(DisplayHandle::borrow_raw(raw_window_handle))
-			}
-			b"wayland" => {
-				use self::raw_window_handle::WaylandDisplayHandle;
+                Ok(DisplayHandle::borrow_raw(raw_window_handle))
+            }
+            b"wayland" => {
+                use self::raw_window_handle::WaylandDisplayHandle;
 
-				let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
+                let window_properties = sys::video::SDL_GetWindowProperties(window.raw());
 
-				let display = SDL_GetPointerProperty(
-					window_properties,
-					sys::video::SDL_PROP_WINDOW_WAYLAND_DISPLAY_POINTER,
-					std::ptr::null_mut(),
-				);
-				let Some(display) = core::ptr::NonNull::<libc::c_void>::new(display) else {
-					return Err(HandleError::Unavailable); // I'm unsure if this is the right error type, of if we should just panic here if the display isn't available?
-				};
-				let handle = WaylandDisplayHandle::new(display);
-				let raw_window_handle = RawDisplayHandle::Wayland(handle);
+                let display = SDL_GetPointerProperty(
+                    window_properties,
+                    sys::video::SDL_PROP_WINDOW_WAYLAND_DISPLAY_POINTER,
+                    std::ptr::null_mut(),
+                );
+                let Some(display) = core::ptr::NonNull::<libc::c_void>::new(display) else {
+                    return Err(HandleError::Unavailable); // I'm unsure if this is the right error type, of if we should just panic here if the display isn't available?
+                };
+                let handle = WaylandDisplayHandle::new(display);
+                let raw_window_handle = RawDisplayHandle::Wayland(handle);
 
-				Ok(DisplayHandle::borrow_raw(raw_window_handle))
-			}
-			_ => {
-				panic!("{video_driver:?} video driver is not supported, please file an issue with raw-window-handle.");
-			}
-		}
-	}
+                Ok(DisplayHandle::borrow_raw(raw_window_handle))
+            }
+            _ => {
+                panic!("{video_driver:?} video driver is not supported, please file an issue with raw-window-handle.");
+            }
+        }
+    }
 }

--- a/src/sdl3/raw_window_handle.rs
+++ b/src/sdl3/raw_window_handle.rs
@@ -20,7 +20,7 @@ pub struct WindowHandles<'a> {
 }
 
 // Note: this is necessary because Wgpu needs the given window handle struct to be Send/Sync
-// Safety: WindowHandles' only job is to store and give out WindowHandle and DisplayHandle values. These handles are simple raw data structs, which means moving and/or referencing WindowHandles across threads is safe. The only methods for WindowHandles simply return the stored raw data, which means using this across threads is safe
+// Safety: WindowHandles is not send/sync safe in the same way that Arc<*mut T> is not send/sync unless T is send/sync. Whether or not the underlying window and display handles are send/sync is an extremely difficult question to answer, so these unsafe impls are likely not sound. It should be noted that WindowHandles itself can be sent, referenced, and accessed across threads safely, but send/sync also requires the returned values to be safely usable across threads (which they likely aren't).
 unsafe impl<'a> Send for WindowHandles<'a> {}
 unsafe impl<'a> Sync for WindowHandles<'a> {}
 
@@ -37,11 +37,11 @@ impl<'a> HasDisplayHandle for WindowHandles<'a> {
 }
 
 impl Window {
-    /// Gives a window handles struct that can be used by crates like wgpu, glutin, etc. Note: using this function means you cannot use methods on `sdl3::video::Window` which take `&mut Self` (such as `window.show()`, `window.minimize()`, etc), if you need to these functions then use `Window::as_window_handles_mut()` instead.
+    /// Gives a window handles struct that can be used by crates like wgpu, glutin, etc. Note: using this function means you cannot use methods on `sdl3::video::Window` which take `&mut Self` (such as `window.show()`, `window.minimize()`, etc), if you need these functions then use `Window::as_window_handles_mut()` instead.
     pub fn as_window_handles<'a>(&'a self) -> Result<WindowHandles<'a>, HandleError> {
         Ok(WindowHandles {
-            window_handle: window_handle(self.raw())?,
-            display_handle: display_handle(self.raw())?,
+            window_handle: get_window_handle(self.raw())?,
+            display_handle: get_display_handle(self.raw())?,
         })
     }
     /// Gives a window handles struct that can be used by crates like wgpu, glutin, etc. Unlike `Window::as_window_handles()`, this gives back a mutable reference which can be used for methods which take `&mut Self` (such as `window.show()`, `window.minimize()`, etc)
@@ -49,15 +49,15 @@ impl Window {
         &'a mut self,
     ) -> Result<(&'a mut Self, WindowHandles<'a>), HandleError> {
         let handle = WindowHandles {
-            window_handle: window_handle(self.raw())?,
-            display_handle: display_handle(self.raw())?,
+            window_handle: get_window_handle(self.raw())?,
+            display_handle: get_display_handle(self.raw())?,
         };
         Ok((self, handle))
     }
 }
 
 // Access window handle using SDL3 properties
-fn window_handle<'a>(raw_window: *mut SDL_Window) -> Result<WindowHandle<'a>, HandleError> {
+fn get_window_handle<'a>(raw_window: *mut SDL_Window) -> Result<WindowHandle<'a>, HandleError> {
     // Windows
     #[cfg(target_os = "windows")]
     unsafe {
@@ -190,7 +190,7 @@ fn window_handle<'a>(raw_window: *mut SDL_Window) -> Result<WindowHandle<'a>, Ha
 }
 
 // Access display handle using SDL3 properties
-fn display_handle<'a>(raw_window: *mut SDL_Window) -> Result<DisplayHandle<'a>, HandleError> {
+fn get_display_handle<'a>(raw_window: *mut SDL_Window) -> Result<DisplayHandle<'a>, HandleError> {
     // Windows
     #[cfg(target_os = "windows")]
     unsafe {

--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -820,7 +820,7 @@ impl ProgressState {
 /// This may happen when a `TextureCreator<Window>` outlives the `Canvas<Window>`
 #[derive(Clone)]
 pub struct Window {
-    context: Arc<WindowContext>, // Arc may not be needed, added because wgpu expects Window to be send/sync, though even with Arc this technically still isn't send/sync
+    context: Arc<WindowContext>,
     hit_test_callback: Option<*mut c_void>,
 }
 

--- a/tests/raw_window_handle.rs
+++ b/tests/raw_window_handle.rs
@@ -12,8 +12,13 @@ mod raw_window_handle_test {
     fn get_windows_handle() {
         use raw_window_handle::RawDisplayHandle;
 
-        let window = new_hidden_window();
-        let window_as_handle = window.as_window_handle().unwrap();
+        let mut window = new_hidden_window();
+        let (window, window_as_handle) = window.mut_as_window_handle().unwrap();
+        window.show();
+        window.minimize();
+        window.restore();
+        window.hide();
+        assert_eq!(window_as_handle, window.as_window_handle().unwrap()); // this doesn't definitively prove that the handle never changes, but it can at least possibly catch cases where it does (which is assumed to be never, but that's why tests exist)
         let window_handle = match window_as_handle.window_handle() {
             Ok(v) => v,
             Err(err) => panic!(
@@ -50,8 +55,13 @@ mod raw_window_handle_test {
     ))]
     #[test]
     fn get_linux_handle() {
-        let window = new_hidden_window();
-        let window_as_handle = window.as_window_handle().unwrap();
+        let mut window = new_hidden_window();
+        let (window, window_as_handle) = window.mut_as_window_handle().unwrap();
+        window.show();
+        window.minimize();
+        window.restore();
+        window.hide();
+        assert_eq!(window_as_handle, window.as_window_handle().unwrap()); // this doesn't definitively prove that the handle never changes, but it can at least possibly catch cases where it does (which is assumed to be never, but that's why tests exist)
         match window_as_handle.window_handle().unwrap().as_raw() {
             RawWindowHandle::Xlib(x11_handle) => {
                 assert_ne!(x11_handle.window, 0, "Window for X11 should not be 0");
@@ -97,8 +107,13 @@ mod raw_window_handle_test {
     #[cfg(target_os = "macos")]
     #[test]
     fn get_macos_handle() {
-        let window = new_hidden_window();
-        let window_as_handle = window.as_window_handle().unwrap();
+        let mut window = new_hidden_window();
+        let (window, window_as_handle) = window.mut_as_window_handle().unwrap();
+        window.show();
+        window.minimize();
+        window.restore();
+        window.hide();
+        assert_eq!(window_as_handle, window.as_window_handle().unwrap()); // this doesn't definitively prove that the handle never changes, but it can at least possibly catch cases where it does (which is assumed to be never, but that's why tests exist)
         let window_handle = match window_as_handle.window_handle() {
             Ok(v) => v,
             Err(err) => panic!(

--- a/tests/raw_window_handle.rs
+++ b/tests/raw_window_handle.rs
@@ -13,7 +13,8 @@ mod raw_window_handle_test {
         use raw_window_handle::RawDisplayHandle;
 
         let window = new_hidden_window();
-        let window_handle = match window.window_handle() {
+        let window_as_handle = window.as_window_handle().unwrap();
+        let window_handle = match window_as_handle.window_handle() {
             Ok(v) => v,
             Err(err) => panic!(
                 "Received error while getting window handle for Windows: {:?}",
@@ -26,7 +27,7 @@ mod raw_window_handle_test {
         };
         assert_ne!(raw_handle.hwnd.get(), 0);
         println!("Successfully received Windows RawWindowHandle!");
-        let display_handle = match window.display_handle() {
+        let display_handle = match window_as_handle.display_handle() {
             Ok(v) => v,
             Err(err) => panic!(
                 "Received error while getting display handle for Windows: {:?}",
@@ -50,8 +51,8 @@ mod raw_window_handle_test {
     #[test]
     fn get_linux_handle() {
         let window = new_hidden_window();
-		let window_handle = window.as_window_handle().unwrap();
-        match window_handle.window_handle().unwrap().as_raw() {
+        let window_as_handle = window.as_window_handle().unwrap();
+        match window_as_handle.window_handle().unwrap().as_raw() {
             RawWindowHandle::Xlib(x11_handle) => {
                 assert_ne!(x11_handle.window, 0, "Window for X11 should not be 0");
                 println!("Successfully received linux X11 RawWindowHandle!");
@@ -70,7 +71,7 @@ mod raw_window_handle_test {
                 x
             ),
         }
-        match window_handle.display_handle().unwrap().as_raw() {
+        match window_as_handle.display_handle().unwrap().as_raw() {
             RawDisplayHandle::Xlib(x11_display) => {
                 assert_ne!(
                     x11_display.display.unwrap().as_ptr(),
@@ -97,7 +98,8 @@ mod raw_window_handle_test {
     #[test]
     fn get_macos_handle() {
         let window = new_hidden_window();
-        let window_handle = match window.window_handle() {
+        let window_as_handle = window.as_window_handle().unwrap();
+        let window_handle = match window_as_handle.window_handle() {
             Ok(v) => v,
             Err(err) => panic!(
                 "Received error while getting window handle for MacOs: {:?}",
@@ -117,7 +119,7 @@ mod raw_window_handle_test {
                 x
             ),
         }
-        let display_handle = match window.display_handle() {
+        let display_handle = match window_as_handle.display_handle() {
             Ok(v) => v,
             Err(err) => panic!(
                 "Received error while getting display handle for MacOS: {:?}",

--- a/tests/raw_window_handle.rs
+++ b/tests/raw_window_handle.rs
@@ -50,7 +50,8 @@ mod raw_window_handle_test {
     #[test]
     fn get_linux_handle() {
         let window = new_hidden_window();
-        match window.window_handle().unwrap().as_raw() {
+		let window_handle = window.as_window_handle().unwrap();
+        match window_handle.window_handle().unwrap().as_raw() {
             RawWindowHandle::Xlib(x11_handle) => {
                 assert_ne!(x11_handle.window, 0, "Window for X11 should not be 0");
                 println!("Successfully received linux X11 RawWindowHandle!");
@@ -69,7 +70,7 @@ mod raw_window_handle_test {
                 x
             ),
         }
-        match window.display_handle().unwrap().as_raw() {
+        match window_handle.display_handle().unwrap().as_raw() {
             RawDisplayHandle::Xlib(x11_display) => {
                 assert_ne!(
                     x11_display.display.unwrap().as_ptr(),

--- a/tests/raw_window_handle.rs
+++ b/tests/raw_window_handle.rs
@@ -13,12 +13,12 @@ mod raw_window_handle_test {
         use raw_window_handle::RawDisplayHandle;
 
         let mut window = new_hidden_window();
-        let (window, window_as_handle) = window.mut_as_window_handle().unwrap();
+        let (window, window_as_handle) = window.as_window_handles_mut().unwrap();
         window.show();
         window.minimize();
         window.restore();
         window.hide();
-        assert_eq!(window_as_handle, window.as_window_handle().unwrap()); // this doesn't definitively prove that the handle never changes, but it can at least possibly catch cases where it does (which is assumed to be never, but that's why tests exist)
+        assert_eq!(window_as_handle, window.as_window_handles().unwrap()); // this doesn't definitively prove that the handle never changes, but it can at least possibly catch cases where it does (which is assumed to be never, but that's why tests exist)
         let window_handle = match window_as_handle.window_handle() {
             Ok(v) => v,
             Err(err) => panic!(
@@ -56,12 +56,12 @@ mod raw_window_handle_test {
     #[test]
     fn get_linux_handle() {
         let mut window = new_hidden_window();
-        let (window, window_as_handle) = window.mut_as_window_handle().unwrap();
+        let (window, window_as_handle) = window.as_window_handles_mut().unwrap();
         window.show();
         window.minimize();
         window.restore();
         window.hide();
-        assert_eq!(window_as_handle, window.as_window_handle().unwrap()); // this doesn't definitively prove that the handle never changes, but it can at least possibly catch cases where it does (which is assumed to be never, but that's why tests exist)
+        assert_eq!(window_as_handle, window.as_window_handles().unwrap()); // this doesn't definitively prove that the handle never changes, but it can at least possibly catch cases where it does (which is assumed to be never, but that's why tests exist)
         match window_as_handle.window_handle().unwrap().as_raw() {
             RawWindowHandle::Xlib(x11_handle) => {
                 assert_ne!(x11_handle.window, 0, "Window for X11 should not be 0");
@@ -108,12 +108,12 @@ mod raw_window_handle_test {
     #[test]
     fn get_macos_handle() {
         let mut window = new_hidden_window();
-        let (window, window_as_handle) = window.mut_as_window_handle().unwrap();
+        let (window, window_as_handle) = window.as_window_handles_mut().unwrap();
         window.show();
         window.minimize();
         window.restore();
         window.hide();
-        assert_eq!(window_as_handle, window.as_window_handle().unwrap()); // this doesn't definitively prove that the handle never changes, but it can at least possibly catch cases where it does (which is assumed to be never, but that's why tests exist)
+        assert_eq!(window_as_handle, window.as_window_handles().unwrap()); // this doesn't definitively prove that the handle never changes, but it can at least possibly catch cases where it does (which is assumed to be never, but that's why tests exist)
         let window_handle = match window_as_handle.window_handle() {
             Ok(v) => v,
             Err(err) => panic!(


### PR DESCRIPTION
This does three things:
- Improves the api for using `sdl3::video::Window` as a `raw_window_handle::HasDisplayHandle` type (previously the example needed a custom type with its own unsafe code, and now it's just `window.as_window_handle()?`)
- Improves the code's threading safety by caching values instead of sending a struct which might call main-thread-only functions on other threads
- Fix the api annoyance that creating a window handle struct removes your ability to use `&mut self` methods on `sdl3::video::Window` due to lifetime restrictions
- Bumps `wgpu`'s version from 29.0.1 to 30.0.0

Edit: [latest safety review](https://github.com/vhspace/sdl3-rs/pull/394#issuecomment-4735272726)