### PR TITLE
ci: fix Windows build by forcing Ninja cmake generator

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -113,17 +113,11 @@ jobs:
       - name: Fetch dependencies
         run: cargo +stable fetch --locked
 
+      # Use the default shell (pwsh on Windows) rather than bash: under Git bash
+      # rustc picks up Git's usr/bin/link.exe instead of the MSVC linker. Keep
+      # the command on one line so it runs the same in bash and pwsh.
       - name: Build
-        shell: bash
-        run: |
-          cargo +stable \
-            build \
-            --verbose \
-            --locked \
-            --offline \
-            --examples \
-            --all-targets \
-            --features "${{ matrix.build_mode }} ${{ matrix.feature }}"
+        run: cargo +stable build --verbose --locked --offline --examples --all-targets --features "${{ matrix.build_mode }} ${{ matrix.feature }}"
 
   tests:
     name: Tests - ${{ matrix.name }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -92,6 +92,19 @@ jobs:
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
 
+      # cmake 0.1.x (build-dep of sdl3-sys) can't auto-detect the Visual Studio
+      # generator on recent windows-latest images and panics with "couldn't
+      # determine visual studio generator". Set up the MSVC env and force the
+      # Ninja generator (bundled with VS) to sidestep the broken detection.
+      - name: Set up MSVC
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+      - name: Use Ninja generator for CMake on Windows
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
+
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:


### PR DESCRIPTION
Windows build jobs have failed on every PR since mid-June. The `cmake` build-dependency of `sdl3-sys` (building SDL3 from source) panics before any crate code is compiled:

```
error: failed to run custom build command for `sdl3-sys v0.6.6+SDL-3.4.10`
  thread 'main' panicked at cmake-0.1.54/src/lib.rs:970:25:
  couldn't determine visual studio generator
```

Successful runs through Jun 9, broken Jun 15 onward across unrelated PRs, which lines up with a `windows-latest` image bump to a Visual Studio version that the pinned cmake-rs can't map to a generator. The workflow had no MSVC setup and never set `CMAKE_GENERATOR`, so it relied entirely on that autodetection.

Set up the MSVC environment with msvc-dev-cmd and force `CMAKE_GENERATOR=Ninja` (Ninja ships with VS) on Windows only, bypassing the broken VS-version detection. Linux and macOS are untouched.

Action is pinned to a commit SHA to match the existing workflow convention.