### PR TITLE
feat: add safe set_blend_constants method

### DIFF
--- a/src/sdl3/gpu/pass.rs
+++ b/src/sdl3/gpu/pass.rs
@@ -5,7 +5,7 @@ use crate::{
         BufferBinding, BufferRegion, GraphicsPipeline, IndexElementSize, LoadOp, StoreOp, Texture,
         TextureRegion, TextureSamplerBinding, TextureTransferInfo, TransferBufferLocation,
     },
-    pixels::Color,
+    pixels::{Color, FColor},
     rect::Rect,
     Error,
 };
@@ -503,6 +503,12 @@ impl RenderPass {
     #[doc(alias = "SDL_SetGPUScissor")]
     pub fn set_scissor(&self, scissor: Rect) {
         unsafe { sys::gpu::SDL_SetGPUScissor(self.inner, scissor.raw()) }
+    }
+
+    #[doc(alias = "SDL_SetGPUBlendConstants")]
+    pub fn set_blend_constants(&self, color: Color) {
+        let color = FColor::from(color);
+        unsafe { sys::gpu::SDL_SetGPUBlendConstants(self.inner, color.raw()) }
     }
 }
 

--- a/src/sdl3/pixels.rs
+++ b/src/sdl3/pixels.rs
@@ -273,7 +273,7 @@ impl FColor {
 
     // Implemented manually and kept private, because reasons
     #[inline]
-    const fn raw(self) -> sys::pixels::SDL_FColor {
+    pub(crate) const fn raw(self) -> sys::pixels::SDL_FColor {
         sys::pixels::SDL_FColor {
             r: self.r,
             g: self.g,


### PR DESCRIPTION
This PR adds a safe wrapper around `SDL_SetGPUBlendConstants`.
I've exposed the `raw` method on `FColor` to the crate - if this isn't an appropriate change, I'm happy to update to manually construct the `SDL_FColor` struct.