### PR TITLE
fix: sync keymod flags with SDL3 (add LEVEL5, rename RESERVED to SCROLL)

### DIFF
--- a/src/sdl3/keyboard/mod.rs
+++ b/src/sdl3/keyboard/mod.rs
@@ -17,6 +17,7 @@ bitflags! {
         const NOMOD = 0x0000;
         const LSHIFTMOD = 0x0001;
         const RSHIFTMOD = 0x0002;
+        const LEVEL5MOD = 0x0004;
         const LCTRLMOD = 0x0040;
         const RCTRLMOD = 0x0080;
         const LALTMOD = 0x0100;
@@ -26,7 +27,7 @@ bitflags! {
         const NUMMOD = 0x1000;
         const CAPSMOD = 0x2000;
         const MODEMOD = 0x4000;
-        const RESERVEDMOD = 0x8000;
+        const SCROLLMOD = 0x8000;
     }
 }
 


### PR DESCRIPTION
Some keymod where missing from the sdl3 doc.
This result in the following result: if the user hit Scroll lock and call keyboard.mod_state(), the:
```rust
        unsafe { Mod::from_bits(sys::keyboard::SDL_GetModState().0).unwrap() }
```
results in a panic.

This sync the code with the sdl3 doc at https://wiki.libsdl.org/SDL3/SDL_Keymod
